### PR TITLE
Replace Future#promise with Future#then

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Fluture
 
-[<img src="https://raw.github.com/fantasyland/fantasy-land/master/logo.png" align="right" width="116" height="116" alt="Fantasy Land" />][1]
+[<img src="https://raw.github.com/fantasyland/fantasy-land/master/logo.png" align="right" width="82" height="82" alt="Fantasy Land" />][1]
+
+[<img src="http://promises-aplus.github.com/promises-spec/assets/logo-small.png" align="right" width="82" height="82" alt="Promises/A+" />][16]
 
 [![NPM Version](https://badge.fury.io/js/fluture.svg)](https://www.npmjs.com/package/fluture)
 [![Dependencies](https://david-dm.org/avaq/fluture.svg)](https://david-dm.org/avaq/fluture)
@@ -72,6 +74,8 @@ all types used within these signatures follows:
   [Fantasy Land Chain specification][13].
 - **Apply** - Any object with an `ap` method which satisfies the
   [Fantasy Land Apply specification][14].
+- **Promise** - Any object with a `then` method which satisfies the
+  [Promise/A+ specification][16].
 
 ### Constructors
 
@@ -375,15 +379,19 @@ Future.reject(new Error('It broke'))
 //> Left([Error: It broke])
 ```
 
-#### `promise :: Future a b ~> Promise b a`
+#### `then :: Future a b ~> (b -> v) | Void, (a -> r) | Void -> Promise r v`
 
-An alternative way to `fork` the Future. This eagerly forks the Future and
-returns a Promise of the result. This is useful if some API wants you to give it
-a Promise. It's the only method which forks the Future without a forced way to
-handle the rejection branch, which means it's considered dangerous to use.
+An alternative way to `fork` the Future, compatible with [Promise/A+][16]. This
+eagerly forks the Future and returns a Promise. Unlike `fork`, when this method
+is called multiple times on the same Future, the underlying computation is only
+ever executed once. Another difference is that both arguments to `then` are
+optional. The existence of this method allows instances of Future to be passed
+to APIs that expect Promises. It's also the only method which forks the Future
+without a forced way to handle the rejection branch, which means it's
+considered dangerous to use.
 
 ```js
-Future.of('Hello').promise().then(console.log);
+Future.of('Hello').then(console.log, console.error);
 //> "Hello"
 ```
 
@@ -486,7 +494,6 @@ readFile('README.md', 'utf8')
 * [ ] Implement Future#and
 * [x] Implement Future#or
 * [ ] Implement Future.predicate
-* [x] Implement Future#promise
 * [x] Implement Future.cast
 * [x] Implement Future.encase
 * [ ] Implement [Profunctor][8] (and possibly rename `chainRej -> lchain`)
@@ -531,3 +538,4 @@ means butterfly in Romanian; A creature you might expect to see in Fantasy Land.
 [13]: https://github.com/fantasyland/fantasy-land#chain
 [14]: https://github.com/fantasyland/fantasy-land#apply
 [15]: https://github.com/Avaq/Fluture/wiki/Comparison-of-Future-Implementations
+[16]: https://promisesaplus.com/

--- a/fluture.js
+++ b/fluture.js
@@ -132,8 +132,8 @@
     if(!isFunction(f)) error$invalidArgument('Future#value', 0, 'be a function', f);
   }
 
-  function check$promise(it){
-    if(!isFluture(it)) error$invalidContext('Future#promise', it);
+  function check$then(it){
+    if(!isFluture(it)) error$invalidContext('Future#then', it);
   }
 
   function check$cache(m){
@@ -309,12 +309,12 @@
     );
   }
 
-  function Future$promise(){
-    check$promise(this);
-    const _this = this;
-    return new Promise(function Future$promise$do(resolve, reject){
-      _this.fork(reject, resolve);
-    });
+  function Future$then(onResolve, onReject){
+    check$then(this);
+    const cached = this._cached || (this._cached = Future.cache(this));
+    return new Promise(function Future$then$do(resolve, reject){
+      cached.fork(reject, resolve);
+    }).then(onResolve, onReject);
   }
 
   //Give Future a prototype.
@@ -336,7 +336,7 @@
     or: Future$or,
     fold: Future$fold,
     value: Future$value,
-    promise: Future$promise
+    then: Future$then
   };
 
   //Expose `of` statically as well.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jsverify": "^0.7.1",
     "mocha": "^2.3.3",
     "nsp": "^2.2.0",
+    "promises-aplus-tests": "^2.1.1",
     "ramda-fantasy": "^0.4.1",
     "rimraf": "^2.4.3"
   }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "strict": 0,
     "no-unused-expressions": 0,
     "no-invalid-this": 0,
     "no-var": 0

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -690,31 +690,14 @@ describe('Future', () => {
 
   });
 
-  describe('#promise()', () => {
+  describe('#then()', () => {
 
     it('throws when invoked out of context', () => {
-      const f = () => Future.of(1).promise.call(null);
+      const f = () => Future.of(1).then.call(null);
       expect(f).to.throw(TypeError, /Future/);
     });
 
-    it('returns a Promise', () => {
-      const actual = Future.of(1).promise();
-      expect(actual).to.be.an.instanceof(Promise);
-    });
-
-    it('resolves if the Future resolves', done => {
-      Future.of(1).promise().then(
-        x => (expect(x).to.equal(1), done()),
-        done
-      );
-    });
-
-    it('rejects if the Future rejects', done => {
-      Future.reject(1).promise().then(
-        () => done(new Error('It resolved')),
-        x => (expect(x).to.equal(1), done())
-      );
-    });
+    require('promises-aplus-tests').mocha(require('./promise-adapter'));
 
   });
 

--- a/test/promise-adapter.js
+++ b/test/promise-adapter.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Future = require('..');
+
+module.exports = {
+
+  resolved: Future.of,
+  rejected: Future.reject,
+
+  deferred: () => {
+
+    let rejected = false, resolved = false, val;
+    const que = [];
+
+    function drainQue(state){
+      for(let i = 0; i < que.length; i++){
+        que[i][state](val);
+        que[i] = undefined;
+      }
+    }
+
+    const m = Future((rej, res) => {
+      rejected ? rej(val) : resolved ? res(val) : que.push({rej, res})
+    });
+
+    return {
+      promise: m,
+      reject: e => rejected || resolved || (rejected = true, val = e, drainQue('rej')),
+      resolve: v => rejected || resolved || (resolved = true, val = v, drainQue('res'))
+    }
+
+  }
+
+};


### PR DESCRIPTION
So I've been having fun with Fluture. At one point I implement `Future#promise` to allow casting to Promise for APIs that consume them, and basically an alternative to `fork`. Today I realized I may as well implement `then`, using the `Future.cache` I already had, combined with the `Future.promise` I already had. Now I can pass Future to APIs that consume promises. And it turns out it passes the Promise/A+ test suite (granted I'm still returning a Promise and not a Future). The downside is that I've introduced a line of code which mutates shared state. The advantage is that `then` is a standardized interface for pulling the value out, as opposed to `fork`.