### PR TITLE
Fix a common bug with do-notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ all types used within these signatures follows:
 
 The Future constructor. Creates a new instance of Future by taking a single
 parameter `fork`: A function which takes two callbacks. Both are continuations
-for an asynchronous computation. The first is `reject`, commonly abreviated to
-`rej`. The second `resolve`, which abreviates to `res`. The `fork` function is
+for an asynchronous computation. The first is `reject`, commonly abbreviated to
+`rej`. The second `resolve`, which abbreviates to `res`. The `fork` function is
 expected to call `rej` once an error occurs, or `res` with the result of the
 asynchronous computation.
 
@@ -362,7 +362,7 @@ Future.of(x => x + 1)
 
 #### `race :: Future a b ~> Future a b -> Future a b`
 
-Race two Futures against eachother. Creates a new Future which resolves or
+Race two Futures against each other. Creates a new Future which resolves or
 rejects with the resolution or rejection value of the first Future to settle.
 
 ```js
@@ -376,7 +376,7 @@ Future.after(100, 'hello')
 
 Logical or for Futures.
 
-Returns a new Future which either resolves with the first resolutation value, or
+Returns a new Future which either resolves with the first resolution value, or
 rejects with the last rejection value once and if both Futures reject.
 
 This behaves analogues to how JavaScript's or operator does, except both
@@ -578,7 +578,10 @@ Returns true for [Forkables](#type-signatures) and false for everything else.
 #### `do :: (() -> Iterator) -> Future a b`
 
 A specialized version of [fantasy-do][19] which works only for Futures, but has
-the advantage of type-checking and not having to pass `Future.of`.
+the advantage of type-checking and not having to pass `Future.of`. Another
+advantage is that the returned Future can be forked multiple times, as opposed
+to with a general `fantasy-do` solution, where forking the Future a second time
+behaves erroneously.
 
 Takes a function which returns an [Iterator](#type-signatures), commonly a
 generator-function, and chains every produced Future over the previous.

--- a/fluture.js
+++ b/fluture.js
@@ -717,14 +717,16 @@
 
   Future.do = function Future$do(f){
     check$do(f);
-    const g = f();
-    check$do$g(g);
-    const next = function Future$do$next(x){
-      const o = g.next(x);
-      check$do$next(o);
-      return o.done ? Future$of(o.value) : o.value.chain(next);
-    };
-    return next();
+    return new FutureClass(function Future$do$fork(rej, res){
+      const g = f();
+      check$do$g(g);
+      const next = function Future$do$next(x){
+        const o = g.next(x);
+        check$do$next(o);
+        return o.done ? Future$of(o.value) : o.value.chain(Future$do$next);
+      };
+      return next().fork(rej, res);
+    });
   };
 
   return Future;

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -1500,19 +1500,21 @@ describe('Other', () => {
 
     it('throws TypeError when the given function does not return an interator', () => {
       const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null, () => {}, {next: 'hello'}];
-      const fs = xs.map(x => () => Future.do(() => x));
+      const fs = xs.map(x => () => Future.do(() => x).fork(noop, noop));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
     });
 
     it('throws TypeError when the returned iterator does not return a valid iteration', () => {
       const xs = [null, '', {}, {done: true}, {value: 1, done: 1}];
-      const fs = xs.map(x => () => Future.do(() => ({next: () => x})));
+      const fs = xs.map(x => () => Future.do(() => ({next: () => x})).fork(noop, noop));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
     });
 
     it('throws TypeError when the returned iterator produces something other than a Future', () => {
       const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-      const fs = xs.map(x => () => Future.do(() => ({next: () => ({done: false, value: x})})));
+      const fs = xs.map(x => () =>
+        Future.do(() => ({next: () => ({done: false, value: x})})).fork(noop, noop)
+      );
       fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
     });
 
@@ -1522,7 +1524,10 @@ describe('Other', () => {
         const b = yield Future.of(2);
         return a + b;
       });
-      return assertResolved(actual, 3);
+      return Promise.all([
+        assertResolved(actual, 3),
+        assertResolved(actual, 3)
+      ]);
     });
 
   });


### PR DESCRIPTION
Commit message:

> Because of the way iterators are "depleted" upon use,
the returned Future could only safely be forked once.

> This is something which is known within the community
to be unfixable in a general way. However, because
Future.do is specialized, I was able to fix it by
respawning the iterator upon every new fork().