### PR TITLE
Add Future.hook()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -83,7 +83,7 @@
     "no-label-var": 2,
     "no-shadow-restricted-names": 2,
     "no-undef": 2,
-    "no-unused-vars": 2,
+    "no-unused-vars": [2, {"argsIgnorePattern": "^_$"}],
     "no-sync": 2,
     "arrow-spacing": [2, {"before": true, "after": true}],
     "constructor-super": 2,

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ getPackageName('package.json')
     * [mapRej](#maprej)
     * [chainRej](#chainrej)
     * [fold](#fold)
+  1. [Resource management](#resource-management)
+    * [hook](#hook)
+    * [finally](#finally)
   1. [Consuming Futures](#consuming-futures)
     * [fork](#fork)
     * [value](#value)
@@ -350,6 +353,34 @@ Future.reject('it broke')
 .value(console.log);
 //> Left('it broke')
 ```
+
+### Resource management
+
+Functions listed under this category allow for more fine-grained control over
+the flow of acquired values.
+
+#### hook
+##### `#hook :: Future a b ~> (b -> Future a c) -> (b -> Future a d) -> Future a d`
+##### `.hook :: Future a b -> (b -> Future a c) -> (b -> Future a d) -> Future a d`
+
+Much like [`chain`](#chain), but takes a "cleanup" computation first, which runs
+*after* the second settles (successfully or unsuccessfully). This allows for
+acquired resources to be disposed, connections to be closed, etc.
+
+```js
+const withConnection = Future.hook(
+  openConnection('localhost'),
+  closeConnection
+);
+
+withConnection(
+  conn => query(conn, 'EAT * cakes FROM bakery')
+)
+.fork(console.error, console.log)
+```
+
+Take care when using this in combination with [`cache`](#cache). Hooking relies
+on the first computation providing a fresh resource every time it's forked.
 
 #### finally
 ##### `#finally :: Future a b ~> Future a c -> Future a b`

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chai": "^3.4.0",
     "codecov": "^1.0.1",
     "data.task": "^3.0.0",
-    "eslint": "^2.2.0",
+    "eslint": "^2.13.1",
     "istanbul": "^0.4.2",
     "jsverify": "^0.7.1",
     "lazy-either": "^1.0.3",


### PR DESCRIPTION
> Much like `chain`, but takes a "cleanup" computation first, which runs
> *after* the second settles (successfully or unsuccessfully). This allows for
> acquired resources to be disposed, connections to be closed, etc.