### PR TITLE
Add Future.Guarded constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ getPackageName('package.json')
   1. [Type signatures](#type-signatures)
   1. [Creating Futures](#creating-futures)
     * [Future](#future)
+    * [Guarded](#guarded)
     * [of](#of)
     * [reject](#reject)
     * [after](#after)
@@ -130,6 +131,23 @@ eventualThing.fork(
   thing => console.log(`Hello ${thing}!`)
 );
 //> "Hello world!"
+```
+
+#### Guarded
+##### `.Guarded :: ((a -> Void), (b -> Void) -> Void) -> Future a b`
+
+A slight variation to the Future constructor. It guarantees that neither of the
+continuations will be called after the first has been called. This is useful
+in cases where the continuations are passed into API's that might call them
+multiple times. For example an event emitter:
+
+```js
+const eventualData = Future.Guarded((rej, res) => {
+  stream.on('data', res).on('error', rej);
+});
+
+//"continuation" will only be called once, even if the stream produces multiple events
+eventualData.fork(console.error, continuation);
 ```
 
 #### of

--- a/bench/guarded.js
+++ b/bench/guarded.js
@@ -1,0 +1,14 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Fluture = require('..');
+
+suite.add('Fluture', () => {
+  Fluture((rej, res) => res(1));
+});
+
+suite.add('Fluture.Guarded', () => {
+  Fluture.Guarded((rej, res) => res(1));
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/fluture.js
+++ b/fluture.js
@@ -353,6 +353,24 @@
     return new FutureClass(f);
   }
 
+  function Guarded(f){
+    check$Future(f);
+    return new FutureClass(function Guarded$fork(rej, res){
+      let open = true;
+      f(function Guarded$rej(x){
+        if(open){
+          open = false;
+          rej(x);
+        }
+      }, function Guarded$res(x){
+        if(open){
+          open = false;
+          res(x);
+        }
+      })
+    });
+  }
+
   function Future$of(x){
     return new FutureClass(function Future$of$fork(rej, res){
       res(x);
@@ -706,6 +724,7 @@
   // Other functions //
   /////////////////////
 
+  Future.Guarded = Guarded;
   Future.isFuture = isFuture;
   Future.isForkable = isForkable;
 

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -109,6 +109,39 @@ describe('Constructors', () => {
 
   });
 
+  describe('Guarded', () => {
+
+    it('throws TypeError when not given a function', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => () => Future.Guarded(x));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('returns a Future when given a function', () => {
+      const actual = Future.Guarded(noop);
+      expect(actual).to.be.an.instanceof(Future);
+    });
+
+    it('ensures no continuations are called after the first resolve', done => {
+      const actual = Future.Guarded((rej, res) => {
+        res(1);
+        res(2);
+        rej(3);
+      });
+      actual.fork(failRej, _ => done());
+    });
+
+    it('ensures no continuations are called after the first reject', done => {
+      const actual = Future.Guarded((rej, res) => {
+        rej(1);
+        rej(2);
+        res(3);
+      });
+      actual.fork(_ => done(), failRes);
+    });
+
+  });
+
   describe('.of()', () => {
 
     it('returns an instance of Future', () => {


### PR DESCRIPTION
There has always been [some confusion](https://github.com/Avaq/Fluture/issues/7) surrounding the fact that the following code: 

```js
Future(rej => setInterval(rej, 100, 'hello')).fork(console.log, console.log)
```

...Will log "hello" to the console continuously. This is especially concerning when wrapping an event-emitter-based API in a Future, because the API might just decide to emit the event multiple times. Now there is `emitter.once()`, but that doesn't help in cases where one event calls the reject-continuation, and another event calls the resolve-continuation:

```js
Future((rej, res) => {
  emitter.once('error', rej).once('done', res);
})
```

When the Future above is forked, it could happen that both continuations are called, and this is in the case where the developer took care to use `once`.

---

One could argue that this behavior is similar to how plain old callbacks work, but there's a reason callbacks are so often associated with hell.

The `Guarded` constructor introduced in this pull-request simply "guards" the continuations for you. Meaning no more continuation will be called after the first has. The goal here is to supply this as an alternative so not to make a breaking change. If the alternative turns out to be practical and has no disadvantages I would like to change the standard `Future` constructor to adopt this new behavior for a `2.0.0` release (which will consequently allow me to remove some safety mechanisms from other parts of the code).

This new behavior does affect performance. The Guarded constructor is twice as slow as the Future constructor (but still 10 times as fast as the Promise constructor). The good news is that internal performance will not be affected. Internal functions don't build on top of the constructor which is exposed to users, but rather a much lighter one which does not have to catch user-land mistakes. So the only time performance will be affected is when the users themselves use the constructor, which I believe is quite rare, and even more rare in hot paths.