### PR TITLE
Add `fs` to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For more information:
 > `npm install --save fluture` <sup>Requires a node 4.0.0 compatible environment</sup>
 
 ```js
+const fs = require('fs');
 const Future = require('fluture');
 
 const getPackageName = file =>


### PR DESCRIPTION
This might seem kind of silly but it makes the example copy-pastable (copy to editor, save, run), which is very friendly for people trying to library out for the first time.

People will get `fs is missing` errors without it and of course those are easily fixed, but we might as well not have users encounter that.