### PR TITLE
Add FantasyLand ChainRec

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A list of all types used within the signatures follows:
 - **Apply** - Values which conform to the [Fantasy Land Apply specification][14].
 - **Iterator** - Objects with `next`-methods which conform to the [Iterator protocol][18].
 - **Iteration** - `{done, value}`-Objects as defined by the [Iterator protocol][18].
-- **Next** - An uncomplete (`{done: false}`) Iteration.
+- **Next** - An incomplete (`{done: false}`) Iteration.
 - **Done** - A complete (`{done: true}`) Iteration.
 - **Cancel** - The nullary cancellation functions returned from computations.
 
@@ -266,7 +266,7 @@ a Future of an [Iteration](#type-signatures). If the Iteration is incomplete
 until it returns a Future of a complete (`{done: true}`) Iteration.
 
 For convenience and interoperability, the first two arguments passed to the
-function are functions for creating an uncomplete Iteration, and for creating a
+function are functions for creating an incomplete Iteration, and for creating a
 complete Iteration, respectively.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ getPackageName('package.json')
     * [try](#try)
     * [encase](#encase)
     * [node](#node)
+    * [loop](#loop)
+    * [chainRec](#chainrec)
   1. [Transforming Futures](#transforming-futures)
     * [map](#map)
     * [bimap](#bimap)
@@ -99,7 +101,7 @@ getPackageName('package.json')
 [<img src="https://raw.githubusercontent.com/rpominov/static-land/master/logo/logo.png" align="right" height="82" alt="Static Land" />][25]
 
 Fluture implements [FantasyLand 1.x][1] and [Static Land][25] compatible
-`Functor`, `Bifunctor`, `Apply`, `Applicative`, `Chain` and `Monad`.
+`Functor`, `Bifunctor`, `Apply`, `Applicative`, `Chain`, `ChainRec` and `Monad`.
 
 ## Documentation
 
@@ -119,7 +121,8 @@ A list of all types used within the signatures follows:
 - **Bifunctor** - Values which conform to the [Fantasy Land Bifunctor specification][24].
 - **Chain** - Values which conform to the [Fantasy Land Chain specification][13].
 - **Apply** - Values which conform to the [Fantasy Land Apply specification][14].
-- **Iterator** - Values which conform to the [Iterator protocol][18].
+- **Iterator** - Objects with `next`-methods which conform to the [Iterator protocol][18].
+- **Iteration** - `{done, value}`-Objects as defined by the [Iterator protocol][18].
 - **Cancel** - The nullary cancellation functions returned from computations.
 
 ### Creating Futures
@@ -250,6 +253,30 @@ Future.node(done => fs.readFile('package.json', 'utf8', done))
 .fork(console.error, console.log)
 //> "{...}"
 ```
+
+#### loop
+##### `.loop :: (b -> Future a (Iteration b)) -> b -> Future a b`
+
+Stack- and memory-safe asynchronous "recursion" based on [FantasyLand ChainRec][26].
+Calls the given function with the initial value, and expects a Future of an
+[Iteration](#type-signatures). If the Iteration is incomplete (`{done: false}`),
+then the function is called again with the Iteration value until it returns a
+Future of a complete (`{done: true}`) Iteration.
+
+```js
+const Next = x => ({done: false, value: x});
+const Done = x => ({done: true, value: x});
+Future.loop((x => Future.of(x < 1000000 ? Next(x + 1) : Done(x))), 0)
+.fork(console.error, console.log);
+//> 1000000
+```
+
+#### chainRec
+##### `.chainRec :: ((((b -> Next b), (b -> Done b), b) -> Future a (Iteration b)), b) -> Future a b`
+
+Fantasy-Land compliant version of [`loop`](#loop). Passes Next and Done
+constructors as first and second arguments to the iteration-function. Used under
+the hood by [`loop`](#loop) and [`do`](#do).
 
 ### Transforming Futures
 
@@ -810,3 +837,4 @@ means butterfly in Romanian; A creature you might expect to see in Fantasy Land.
 [23]: https://vimeo.com/106008027
 [24]: https://github.com/fantasyland/fantasy-land#bifunctor
 [25]: https://github.com/rpominov/static-land
+[26]: https://github.com/fantasyland/fantasy-land#chainrec

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Future.node(done => fs.readFile('package.json', 'utf8', done))
 ```
 
 #### chainRec
-##### `.chainRec :: (((b -> Next), (c -> Done), b) -> Future a Iteration) -> b -> Future a c`
+##### `.chainRec :: ((b -> Next, c -> Done, b) -> Future a Iteration) -> b -> Future a c`
 
 Stack- and memory-safe asynchronous "recursion" based on [FantasyLand ChainRec][26].
 

--- a/bench/chainRec.js
+++ b/bench/chainRec.js
@@ -1,0 +1,24 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const RamdaFuture = require('ramda-fantasy').Future;
+const FunTask = require('fun-task');
+const Fluture = require('..');
+
+const noop = () => {};
+const iterator = of => (next, done, x) => x < 1 ? of(next(x + 0.0001)) : of(done(x));
+
+suite.add('Fluture', () => {
+  Fluture.chainRec(iterator(Fluture.of), 0).fork(noop, noop);
+});
+
+suite.add('Ramda Fantasy', () => {
+  RamdaFuture.chainRec(iterator(RamdaFuture.of), 0).fork(noop, noop);
+});
+
+const handlers = {success: noop, failure: noop};
+suite.add('FunTask', () => {
+  FunTask.chainRec(iterator(FunTask.of), 0).run(handlers);
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/fluture.js
+++ b/fluture.js
@@ -171,10 +171,6 @@
     if(!isFunction(f)) error$invalidArgument('Future#chain', 0, 'be a function', f);
   }
 
-  function check$loop(f){
-    if(!isFunction(f)) error$invalidArgument('Future.loop', 0, 'be a function', f);
-  }
-
   function check$chainRec(f){
     if(!isFunction(f)) error$invalidArgument('Future.chainRec', 0, 'be a function', f);
     if(!isTernary(f)) error$invalidArgument('Future.chainRec', 0, 'take three arguments', f);
@@ -196,6 +192,9 @@
       + ' Iteration every time it is called. The Future returned from'
       + (ordinal[i] ? ` the ${ordinal[i]} call` : ` call ${i}`)
       + ' did not resolve to a member of Iteration.'
+      + '\n  You can create an uncomplete or complete Iteration using the next'
+      + ' or done functions respectively. These are passed into your callback'
+      + ' as first and second arguments.'
       + `\n  Actual: Future.of(${show(it)})`
     );
   }
@@ -399,6 +398,7 @@
   }
 
   function Future$chainRec(f, init){
+    if(arguments.length === 1) return unaryPartial(Future$chainRec, f);
     check$chainRec(f);
     return new FutureClass(function(rej, res){
       let cancel = noop, i = 0;
@@ -902,14 +902,6 @@
       ms.slice(0, i).forEach(fork);
       return function Future$parallel$cancel(){ cs.forEach(call) };
     });
-  };
-
-  Future.loop = function Future$loop(f, init){
-    if(arguments.length === 1) return unaryPartial(Future.loop, f);
-    check$loop(f);
-    return Future$chainRec(function Future$loop$chainRec(a, b, x){
-      return f(x);
-    }, init);
   };
 
   Future.do = function Future$do(f){

--- a/fluture.js
+++ b/fluture.js
@@ -60,14 +60,16 @@
     return n === Infinity || (typeof n === 'number' && n > 0 && n % 1 === 0 && n === n);
   }
 
-  function isIterator(i){
-    return Boolean(i) && typeof i.next === 'function';
+  function isObject(o){
+    return o !== null && typeof o === 'object';
   }
 
-  const hasProp = Object.prototype.hasOwnProperty;
+  function isIterator(i){
+    return isObject(i) && typeof i.next === 'function';
+  }
 
   function isIteration(o){
-    return Boolean(o) && typeof o.done === 'boolean' && hasProp.call(o, 'value');
+    return isObject(o) && typeof o.done === 'boolean';
   }
 
   ///////////////
@@ -731,6 +733,7 @@
     isBinary,
     isTernary,
     isPositiveInteger,
+    isObject,
     isIterator,
     isIteration,
     preview,

--- a/fluture.js
+++ b/fluture.js
@@ -177,7 +177,7 @@
 
   function check$chainRec(f){
     if(!isFunction(f)) error$invalidArgument('Future.chainRec', 0, 'be a function', f);
-    if(!isTernary(f)) error$invalidArgument('Future.chainRec', 0, 'take at least three arguments', f);
+    if(!isTernary(f)) error$invalidArgument('Future.chainRec', 0, 'take three arguments', f);
   }
 
   function check$chainRec$f(m, f, i, x){
@@ -331,12 +331,12 @@
 
   function check$encase2(f){
     if(!isFunction(f)) error$invalidArgument('Future.encase2', 0, 'be a function', f);
-    if(!isBinary(f)) error$invalidArgument('Future.encase2', 0, 'take at least two arguments', f);
+    if(!isBinary(f)) error$invalidArgument('Future.encase2', 0, 'take two arguments', f);
   }
 
   function check$encase3(f){
     if(!isFunction(f)) error$invalidArgument('Future.encase3', 0, 'be a function', f);
-    if(!isTernary(f)) error$invalidArgument('Future.encase3', 0, 'take at least three arguments', f);
+    if(!isTernary(f)) error$invalidArgument('Future.encase3', 0, 'take three arguments', f);
   }
 
   function check$node(f){
@@ -402,8 +402,8 @@
     check$chainRec(f);
     return new FutureClass(function(rej, res){
       let cancel = noop, i = 0;
-      (function Future$chainRec$recur(value){
-        let isSync = null, state = Next(value);
+      (function Future$chainRec$recur(state){
+        let isSync = null;
         function Future$chainRec$res(it){
           check$chainRec$it(it, i);
           i = i + 1;
@@ -411,7 +411,7 @@
             isSync = true;
             state = it;
           }else{
-            (it.done ? res : Future$chainRec$recur)(it.value);
+            Future$chainRec$recur(it);
           }
         }
         while(!state.done){
@@ -427,7 +427,7 @@
           }
         }
         res(state.value);
-      }(init));
+      }(Next(init)));
       return function Future$chainRec$cancel(){ cancel() };
     });
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "data.task": "^3.0.0",
     "eslint": "^3.0.1",
     "fantasy-land": "^1.0.1",
-    "fun-task": "^1.1.1",
+    "fun-task": "^1.5.1",
     "istanbul": "^0.4.2",
     "jsverify": "^0.7.1",
     "lazy-either": "^1.0.3",
@@ -68,7 +68,7 @@
     "nsp": "^2.2.0",
     "pacta": "^0.9.0",
     "ramda": "^0.22.1",
-    "ramda-fantasy": "^0.6.0",
+    "ramda-fantasy": "^0.7.0",
     "rimraf": "^2.4.3",
     "sanctuary": "^0.11.1"
   }

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -514,6 +514,10 @@ describe('Constructors', () => {
 
   describe('.chainRec()', () => {
 
+    it('is curried', () => {
+      expect(Future.chainRec(noop)).to.be.a('function');
+    });
+
     it('throws TypeError when not given a function', () => {
       const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
       const fs = xs.map(x => _ => Future.chainRec(x, 1));
@@ -577,7 +581,7 @@ describe('Constructors', () => {
     });
 
     it('can be cancelled straight away', done => {
-      Future.chainRec((f, g, x) => Future.after(10, g(x))).fork(failRej, failRes)();
+      Future.chainRec((f, g, x) => Future.after(10, g(x)), 1).fork(failRej, failRes)();
       setTimeout(done, 20);
     });
 
@@ -586,28 +590,6 @@ describe('Constructors', () => {
       const cancel = m.fork(failRej, failRes);
       setTimeout(cancel, 25);
       setTimeout(done, 70);
-    });
-
-  });
-
-  describe('.loop()', () => {
-
-    it('is curried', () => {
-      expect(Future.loop(noop)).to.be.a('function');
-    });
-
-    it('throws TypeError when not given a function', () => {
-      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-      const fs = xs.map(x => _ => Future.loop(x, 1));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('calls the function with the value from the current iteration', () => {
-      let i = 0;
-      Future.loop(x => {
-        expect(x).to.equal(i);
-        return x < 5 ? Future.of(Future.util.Next(++i)) : Future.of(Future.util.Done(x));
-      }, i).fork(noop, noop);
     });
 
   });

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -7,6 +7,7 @@ const jsc = require('jsverify');
 const S = require('sanctuary');
 const FL = require('fantasy-land');
 
+const STACKSIZE = (function r(){try{return 1 + r()}catch(e){return 1}}());
 const noop = () => {};
 const add = a => b => a + b;
 const error = new Error('Intentional error for unit testing');
@@ -96,34 +97,34 @@ describe('Constructors', () => {
       actual.fork(_ => done(), failRes);
     });
 
-    describe('error message', () => {
-
-      it('takes it easy with the recursive data structures', () => {
-        const data = {foo: 'bar'};
-        data.data = data;
-        const f = () => Future(data);
-        expect(f).to.throw(TypeError, /Future/);
+    it('prevents chains from running twice', done => {
+      const m = Future((rej, res) => {
+        res(1);
+        res(1);
       });
+      m.map(x => {
+        done();
+        return x;
+      })
+      .fork(failRej, noop);
+    });
 
-      it('displays nested named functions by their name', () => {
-        function nyerk(){}
-        const data = {foo: nyerk};
-        const f = () => Future(data);
-        expect(f).to.throw(TypeError, /\[Function: nyerk\]/);
+    it('stops continuations from being called after cancellation', done => {
+      Future((rej, res) => {
+        setTimeout(res, 20, 1);
+        setTimeout(rej, 20, 1);
+      })
+      .fork(failRej, failRes)();
+      setTimeout(done, 25);
+    });
+
+    it('stops cancellation from being called after continuations', () => {
+      const m = Future((rej, res) => {
+        res(1);
+        return () => { throw error };
       });
-
-      it('displays nested anonymous functions', () => {
-        const data = {foo: () => {}};
-        const f = () => Future(data);
-        expect(f).to.throw(TypeError, /\[Function(: foo)?\]/);
-      });
-
-      it('displays nested arrays', () => {
-        const data = {foo: ['a', 'b', 'c']};
-        const f = () => Future(data);
-        expect(f).to.throw(TypeError, /\[Array: 3\]/);
-      });
-
+      const cancel = m.fork(failRej, noop);
+      cancel();
     });
 
   });
@@ -455,6 +456,158 @@ describe('Constructors', () => {
       const cancel = Future.parallel(1, [delayedRej, delayedRej]).fork(failRej, failRes);
       setTimeout(cancel, 10);
       setTimeout(done, 50);
+    });
+
+  });
+
+  describe('.do()', () => {
+
+    it('throws TypeError when not given a function', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => () => Future.do(x));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('throws TypeError when the given function does not return an interator', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null, () => {}, {next: 'hello'}];
+      const fs = xs.map(x => () => Future.do(() => x).fork(noop, noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('throws TypeError when the returned iterator does not return a valid iteration', () => {
+      const xs = [null, '', {}, {done: true}, {value: 1, done: 1}];
+      const fs = xs.map(x => () => Future.do(() => ({next: () => x})).fork(noop, noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('throws TypeError when the returned iterator produces something other than a Future', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => () =>
+        Future.do(() => ({next: () => ({done: false, value: x})})).fork(noop, noop)
+      );
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('can be used to chain Futures in do-notation', () => {
+      const actual = Future.do(function*(){
+        const a = yield Future.of(1);
+        const b = yield Future.of(2);
+        return a + b;
+      });
+      return Promise.all([
+        assertResolved(actual, 3),
+        assertResolved(actual, 3)
+      ]);
+    });
+
+    it('is stack safe', () => {
+      const gen = function*(){
+        let i = 0;
+        while(i < STACKSIZE + 1) yield Future.of(i++);
+        return i;
+      };
+      const m = Future.do(gen);
+      return assertResolved(m, STACKSIZE + 1);
+    });
+
+  });
+
+  describe('.chainRec()', () => {
+
+    it('throws TypeError when not given a function', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => _ => Future.chainRec(x, 1));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('throws TypeError when the given function is not ternary', () => {
+      const xs = [() => {}, (_) => {}, (a, _) => {}];
+      const fs = xs.map(x => _ => Future.chainRec(x, 1));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future.*three/));
+    });
+
+    it('throws TypeError when the given function does not return a Future', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => _ => Future.chainRec((a, b, _) => x, 1).fork(noop, noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future.*first call/));
+    });
+
+    it('throws TypeError when the given function does not always return a Future', () => {
+      const recur = (a, b, i) => i <= 6 ? Future.of(Future.util.Next(i + 1)) : 'hello';
+      const f = _ => Future.chainRec(recur, 1).fork(noop, noop);
+      expect(f).to.throw(TypeError, /Future.*6/);
+    });
+
+    it('throws TypeError when the returned Future does not contain an iteration', () => {
+      const xs = [null, '', {}, {done: true}, {value: 1, done: 1}];
+      const fs = xs.map(x => _ => Future.chainRec((a, b, _) => Future.of(x), 1).fork(noop, noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future.*first call/));
+    });
+
+    it('throws TypeError when the returned Future does not always contain an iteration', () => {
+      const recur = (a, b, i) => i <= 6 ? Future.of(Future.util.Next(i + 1)) : Future.of('hello');
+      const f = _ => Future.chainRec(recur, 1).fork(noop, noop);
+      expect(f).to.throw(TypeError, /Future.*6/);
+    });
+
+    it('calls the function with Next, Done and the initial value', () => {
+      Future.chainRec((f, g, x) => {
+        expect(f).to.be.a('function');
+        expect(f.length).to.equal(1);
+        expect(f(x)).to.deep.equal(Future.util.Next(x));
+        expect(g).to.be.a('function');
+        expect(g.length).to.equal(1);
+        expect(g(x)).to.deep.equal(Future.util.Done(x));
+        expect(x).to.equal(42);
+        return Future.of(g(x));
+      }, 42).fork(noop, noop);
+    });
+
+    it('calls the function with the value from the current iteration', () => {
+      let i = 0;
+      Future.chainRec((f, g, x) => {
+        expect(x).to.equal(i);
+        return x < 5 ? Future.of(f(++i)) : Future.of(g(x));
+      }, i).fork(noop, noop);
+    });
+
+    it('works asynchronously', () => {
+      const actual = Future.chainRec((f, g, x) => Future.after(10, x < 5 ? f(x + 1) : g(x)), 0);
+      return assertResolved(actual, 5);
+    });
+
+    it('can be cancelled straight away', done => {
+      Future.chainRec((f, g, x) => Future.after(10, g(x))).fork(failRej, failRes)();
+      setTimeout(done, 20);
+    });
+
+    it('can be cancelled after some iterations', done => {
+      const m = Future.chainRec((f, g, x) => Future.after(10, x < 5 ? f(x + 1) : g(x)), 0);
+      const cancel = m.fork(failRej, failRes);
+      setTimeout(cancel, 25);
+      setTimeout(done, 70);
+    });
+
+  });
+
+  describe('.loop()', () => {
+
+    it('is curried', () => {
+      expect(Future.loop(noop)).to.be.a('function');
+    });
+
+    it('throws TypeError when not given a function', () => {
+      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      const fs = xs.map(x => _ => Future.loop(x, 1));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('calls the function with the value from the current iteration', () => {
+      let i = 0;
+      Future.loop(x => {
+        expect(x).to.equal(i);
+        return x < 5 ? Future.of(Future.util.Next(++i)) : Future.of(Future.util.Done(x));
+      }, i).fork(noop, noop);
     });
 
   });
@@ -1336,6 +1489,29 @@ describe('Compliance', function(){
       ));
     });
 
+    describe('ChainRec', () => {
+
+      test('equivalence', x => {
+        const p = v => v < 1;
+        const d = of;
+        const n = B(of)(v => v - 1);
+        const a = Future[FL.chainRec]((l, r, v) => p(v) ? d(v)[FL.map](r) : n(v)[FL.map](l), x);
+        const b = (function step(v){ return p(v) ? d(v) : n(v)[FL.chain](step) }(x));
+        return eq(a, b);
+      });
+
+      it('is stack safe', () => {
+        const p = v => v > (STACKSIZE + 1);
+        const d = of;
+        const n = B(of)(v => v + 1);
+        const a = Future[FL.chainRec]((l, r, v) => p(v) ? d(v)[FL.map](r) : n(v)[FL.map](l), 0);
+        const b = (function step(v){ return p(v) ? d(v) : n(v)[FL.chain](step) }(0));
+        expect(_ => a.fork(noop, noop)).to.not.throw();
+        expect(_ => b.fork(noop, noop)).to.throw(/call stack/);
+      });
+
+    });
+
     describe('Monad', () => {
       test('left identity', x => eq(
         B(of)(sub3)(x),
@@ -1402,6 +1578,29 @@ describe('Compliance', function(){
         F.chain(B(of)(sub3), F.chain(B(of)(mul3), of(x))),
         F.chain(y => F.chain(B(of)(sub3), B(of)(mul3)(y)), of(x))
       ));
+    });
+
+    describe('ChainRec', () => {
+
+      test('equivalence', x => {
+        const p = v => v < 1;
+        const d = of;
+        const n = B(of)(v => v - 1);
+        const a = F.chainRec((l, r, v) => p(v) ? F.map(r, d(v)) : F.map(l, n(v)), x);
+        const b = (function step(v){ return p(v) ? d(v) : F.chain(step, n(v)) }(x));
+        return eq(a, b);
+      });
+
+      it('is stack safe', () => {
+        const p = v => v > (STACKSIZE + 1);
+        const d = of;
+        const n = B(of)(v => v + 1);
+        const a = F.chainRec((l, r, v) => p(v) ? F.map(r, d(v)) : F.map(l, n(v)), 0);
+        const b = (function step(v){ return p(v) ? d(v) : F.chain(step, n(v)) }(0));
+        expect(_ => a.fork(noop, noop)).to.not.throw();
+        expect(_ => b.fork(noop, noop)).to.throw(/call stack/);
+      });
+
     });
 
     describe('Monad', () => {
@@ -1969,84 +2168,56 @@ describe('Utility functions', () => {
 
   });
 
-});
+  describe('.Next()', () => {
 
-describe('Other', () => {
-
-  describe('.do()', () => {
-
-    it('throws TypeError when not given a function', () => {
-      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-      const fs = xs.map(x => () => Future.do(x));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('throws TypeError when the given function does not return an interator', () => {
-      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null, () => {}, {next: 'hello'}];
-      const fs = xs.map(x => () => Future.do(() => x).fork(noop, noop));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('throws TypeError when the returned iterator does not return a valid iteration', () => {
-      const xs = [null, '', {}, {done: true}, {value: 1, done: 1}];
-      const fs = xs.map(x => () => Future.do(() => ({next: () => x})).fork(noop, noop));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('throws TypeError when the returned iterator produces something other than a Future', () => {
-      const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-      const fs = xs.map(x => () =>
-        Future.do(() => ({next: () => ({done: false, value: x})})).fork(noop, noop)
-      );
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('can be used to chain Futures in do-notation', () => {
-      const actual = Future.do(function*(){
-        const a = yield Future.of(1);
-        const b = yield Future.of(2);
-        return a + b;
-      });
-      return Promise.all([
-        assertResolved(actual, 3),
-        assertResolved(actual, 3)
-      ]);
+    it('returns an uncomplete Iteration of the given value', () => {
+      const actual = util.Next(42);
+      expect(util.isIteration(actual)).to.equal(true);
+      expect(actual.done).to.equal(false);
+      expect(actual.value).to.equal(42);
     });
 
   });
 
-  describe('Guarded', () => {
+  describe('.Done()', () => {
 
-    it('prevents chains from running twice', done => {
-      const m = Future((rej, res) => {
-        res(1);
-        res(1);
-      });
-      m.map(x => {
-        done();
-        return x;
-      })
-      .fork(failRej, noop);
+    it('returns a complete Iteration of the given value', () => {
+      const actual = util.Done(42);
+      expect(util.isIteration(actual)).to.equal(true);
+      expect(actual.done).to.equal(true);
+      expect(actual.value).to.equal(42);
     });
 
-    it('stops continuations from being called after cancellation', done => {
-      Future((rej, res) => {
-        setTimeout(res, 20, 1);
-        setTimeout(rej, 20, 1);
-      })
-      .fork(failRej, failRes)();
-      setTimeout(done, 25);
-    });
+  });
 
-    it('stops cancellation from being called after continuations', () => {
-      const m = Future((rej, res) => {
-        res(1);
-        return () => { throw error };
-      });
-      const cancel = m.fork(failRej, noop);
-      cancel();
-    });
+});
 
+describe('Error messages', () => {
+
+  it('take it easy with the recursive data structures', () => {
+    const data = {foo: 'bar'};
+    data.data = data;
+    const f = () => Future(data);
+    expect(f).to.throw(TypeError, /Future/);
+  });
+
+  it('display nested named functions by their name', () => {
+    function nyerk(){}
+    const data = {foo: nyerk};
+    const f = () => Future(data);
+    expect(f).to.throw(TypeError, /\[Function: nyerk\]/);
+  });
+
+  it('display nested anonymous functions', () => {
+    const data = {foo: () => {}};
+    const f = () => Future(data);
+    expect(f).to.throw(TypeError, /\[Function(: foo)?\]/);
+  });
+
+  it('display nested arrays', () => {
+    const data = {foo: ['a', 'b', 'c']};
+    const f = () => Future(data);
+    expect(f).to.throw(TypeError, /\[Array: 3\]/);
   });
 
 });

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -585,6 +585,18 @@ describe('Constructors', () => {
       return assertResolved(actual, 5);
     });
 
+    it('responds to failure', () => {
+      const m = Future.chainRec((f, g, x) => Future.reject(x), 1);
+      return assertRejected(m, 1);
+    });
+
+    it('responds to failure after chaining async', () => {
+      const m = Future.chainRec(
+        (f, g, x) => x < 2 ? Future.after(10, f(x + 1)) : Future.reject(x), 0
+      );
+      return assertRejected(m, 2);
+    });
+
     it('can be cancelled straight away', done => {
       Future.chainRec((f, g, x) => Future.after(10, g(x)), 1).fork(failRej, failRes)();
       setTimeout(done, 20);

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -521,14 +521,14 @@ describe('Constructors', () => {
     });
 
     it('throws TypeError when the given function is not ternary', () => {
-      const xs = [() => {}, (_) => {}, (a, _) => {}];
+      const xs = [() => {}, (a) => a, (a, b) => b];
       const fs = xs.map(x => _ => Future.chainRec(x, 1));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future.*three/));
     });
 
     it('throws TypeError when the given function does not return a Future', () => {
       const xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-      const fs = xs.map(x => _ => Future.chainRec((a, b, _) => x, 1).fork(noop, noop));
+      const fs = xs.map(x => _ => Future.chainRec((a, b, c) => (c, x), 1).fork(noop, noop));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future.*first call/));
     });
 
@@ -540,7 +540,7 @@ describe('Constructors', () => {
 
     it('throws TypeError when the returned Future does not contain an iteration', () => {
       const xs = [null, '', {}, {done: true}, {value: 1, done: 1}];
-      const fs = xs.map(x => _ => Future.chainRec((a, b, _) => Future.of(x), 1).fork(noop, noop));
+      const fs = xs.map(x => _ => Future.chainRec((a, b, c) => Future.of((c, x)), 1).fork(noop, noop));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future.*first call/));
     });
 
@@ -644,7 +644,7 @@ describe('Future', () => {
     });
 
     it('throws TypeError when the computation returns nonsense', () => {
-      const xs = [null, 1, (_) => {}, (x, _) => {}, 'hello'];
+      const xs = [null, 1, (_) => {}, (a, b) => b, 'hello'];
       const ms = xs.map(x => Future(_ => x));
       const fs = ms.map(m => () => m.fork(noop, noop));
       fs.forEach(f => expect(f).to.throw(TypeError, /Future/));

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -1990,22 +1990,6 @@ describe('Utility functions', () => {
 
   });
 
-  describe('.isObject()', () => {
-
-    function O(){}
-    const os = [{}, {foo: 1}, Object.create(null), new O, []];
-    const xs = [1, true, NaN, null, undefined, ''];
-
-    it('returns true when given an Object', () => {
-      os.forEach(i => expect(util.isObject(i)).to.equal(true));
-    });
-
-    it('returns false when not given an Object', () => {
-      xs.forEach(x => expect(util.isObject(x)).to.equal(false));
-    });
-
-  });
-
   describe('.isIterator()', () => {
 
     const is = [{next: () => {}}, {next: x => x}, (function*(){}())];

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -545,7 +545,7 @@ describe('Constructors', () => {
     });
 
     it('throws TypeError when the returned Future does not always contain an iteration', () => {
-      const recur = (a, b, i) => i <= 6 ? Future.of(Future.util.Next(i + 1)) : Future.of('hello');
+      const recur = (a, b, i) => i <= 6 ? Future.of(a(i + 1)) : Future.of('hello');
       const f = _ => Future.chainRec(recur, 1).fork(noop, noop);
       expect(f).to.throw(TypeError, /Future.*6/);
     });


### PR DESCRIPTION
Fixes #23 and also makes `.do()` memory- and stack-safe.

I decided to add an abstraction over `chainRec` I called `loop`. It's `chainRec`, but curried and the function is unary. This to me seemed like a more user-friendly version for direct use, since my `done` and `next` construct [Iterations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterator), which should be quite easy for a user to do in user-land. But I would like feedback on this decision. Note that `chainRec` is also available because of Static-Land, but it's not quite as documented.

ping @safareli @rpominov :)