### PR TITLE
Refactor to classes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -119,7 +119,6 @@
     "no-trailing-spaces": 2,
     "no-unneeded-ternary": 2,
     "object-curly-spacing": [2, "never"],
-    "operator-linebreak": [2, "before"],
     "padded-blocks": 0,
     "semi-spacing": [2, {"before": false, "after": true}],
     "space-before-blocks": [2, "never"],

--- a/README.md
+++ b/README.md
@@ -331,9 +331,9 @@ Future.of(1)
 ```
 
 Note that, due to its lazy nature, the stack and/or heap will slowly fill up as
-you're you chain more and more over the same structure. It's therefore
-recommended that you use [`chainRec`](#chainrec) in cases where you wish to
-`chain` recursively or traverse a large list (10000+ items).
+you chain more over the same structure. It's therefore recommended that you use
+[`chainRec`](#chainrec) in cases where you wish to `chain` recursively or
+traverse a large list (10000+ items).
 
 #### ap
 ##### `#ap :: Future a b ~> Future a (b -> c) -> Future a c`

--- a/README.md
+++ b/README.md
@@ -466,9 +466,12 @@ const closeConnection = conn => Future((rej, res) => {
 
   //We try to dispose gracefully.
   conn.flushGracefully(err => {
-    if(err) return rej(err);
-    conn.close();
-    res();
+    if(err === null){
+      conn.close();
+      res();
+    }else{
+      rej(err);
+    }
   });
 
   //On cancel, we force dispose.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ getPackageName('package.json')
     * [map](#map)
     * [bimap](#bimap)
     * [chain](#chain)
-    * [recur](#recur)
     * [ap](#ap)
     * [swap](#swap)
   1. [Error handling](#error-handling)
@@ -331,19 +330,10 @@ Future.of(1)
 //> 2
 ```
 
-#### recur
-##### `#recur :: Future a b ~> (b -> Future a c) -> Future a c`
-##### `.recur :: (b -> Future a c) -> Future a b -> Future a c`
-
-An alternative version of `chain` which does not build up the cancel function.
-This is useful in the case of a never-resolving recursive computation, in
-order to prevent stack-overflow or out-of-memory errors:
-
-```js
-const recursive = () => Future.after(200, 'world').recur(recursive);
-const cancel = recursive();
-process.on('SIGINT', cancel);
-```
+Note that, due to its lazy nature, the stack and/or heap will slowly fill up as
+you're you chain more and more over the same structure. It's therefore
+recommended that you use [`chainRec`](#chainrec) in cases where you wish to
+`chain` recursively or traverse a large list (10000+ items).
 
 #### ap
 ##### `#ap :: Future a b ~> Future a (b -> c) -> Future a c`

--- a/bench/cache.js
+++ b/bench/cache.js
@@ -26,7 +26,7 @@ suite.add('Fluture', () => {
 });
 
 suite.add('Ramda Fantasy', () => {
-  const future = RamdaFuture.cache(Fluture.of(1));
+  const future = RamdaFuture.cache(RamdaFuture.of(1));
   addTenMaps(future);
   future.fork(noop, noop);
 });

--- a/bench/curry.js
+++ b/bench/curry.js
@@ -1,30 +1,55 @@
 const benchmark = require('benchmark');
 const suite = new benchmark.Suite();
 const curry = require('lodash.curry');
+const {util} = require('..');
 
 const lodash = curry(function(a, b){
   return a + b;
 });
 
-const manual = function(a, b){
-  if(arguments.length === 1) return b => manual(a, b);
+function manual(a, b){
+  if(arguments.length === 1) return util.unaryPartial(manual, a);
   return a + b;
-};
+}
+
+function manual3if(a, b, c, d){
+  if(arguments.length === 1) return util.unaryPartial(manual3if, a);
+  if(arguments.length === 2) return util.binaryPartial(manual3if, a, b);
+  if(arguments.length === 3) return util.ternaryPartial(manual3if, a, b, c);
+  return a + b + c + d;
+}
+
+function manual3switch(a, b, c, d){
+  switch(arguments.length){
+    case 1: return util.unaryPartial(manual3switch, a);
+    case 2: return util.binaryPartial(manual3switch, a, b);
+    case 3: return util.ternaryPartial(manual3switch, a, b, c);
+    default: return a + b + c + d;
+  }
+}
 
 suite.add('Lodash uncurried', () => {
   lodash(1, 2);
-});
-
-suite.add('Manual uncurried', () => {
-  manual(1, 2);
 });
 
 suite.add('Lodash curried', () => {
   lodash(1)(2);
 });
 
+suite.add('Manual uncurried', () => {
+  manual(1, 2);
+});
+
 suite.add('Manual curried', () => {
   manual(1)(2);
+});
+
+suite.add('Manual 3 (if)', () => {
+  manual3if(1)(2)(3)(4);
+});
+
+suite.add('Manual 3 (switch)', () => {
+  manual3switch(1)(2)(3)(4);
 });
 
 suite.on('complete', require('./_print'))

--- a/bench/or.js
+++ b/bench/or.js
@@ -1,0 +1,28 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Future = require('..');
+
+const noop = () => {};
+const a = Future.of('a');
+const b = Future.of('b');
+const _a = Future.reject('!a');
+const _b = Future.reject('!b');
+
+suite.add('res res', () => {
+  a.or(b).fork(noop, noop);
+});
+
+suite.add('rej rej', () => {
+  _a.or(_b).fork(noop, noop);
+});
+
+suite.add('rej res', () => {
+  _a.or(b).fork(noop, noop);
+});
+
+suite.add('res rej', () => {
+  a.or(_b).fork(noop, noop);
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/bench/parallel.js
+++ b/bench/parallel.js
@@ -1,0 +1,32 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Future = require('..');
+
+const noop = () => {};
+const makeArr = length => Array.from({length}, (_, i) => Future.of(i));
+const empty = makeArr(0);
+const small = makeArr(2);
+const big = makeArr(100);
+
+suite.add('Empty', () => {
+  Future.parallel(1, empty).fork(noop, noop);
+});
+
+suite.add('Small concurrent', () => {
+  Future.parallel(2, small).fork(noop, noop);
+});
+
+suite.add('Small sequential', () => {
+  Future.parallel(1, small).fork(noop, noop);
+});
+
+suite.add('Big concurrent', () => {
+  Future.parallel(Infinity, big).fork(noop, noop);
+});
+
+suite.add('Big sequential', () => {
+  Future.parallel(5, big).fork(noop, noop);
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/bench/race.js
+++ b/bench/race.js
@@ -1,0 +1,26 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Future = require('..');
+
+const noop = () => {};
+const a = Future.of('a');
+const b = Future.after(5, 'b');
+
+suite.add('Left winner', () => {
+  a.race(b).fork(noop, noop);
+});
+
+suite.add('Right winner', () => {
+  b.race(a).fork(noop, noop);
+});
+
+suite.add('Both fast', () => {
+  a.race(a).fork(noop, noop);
+});
+
+suite.add('Both slow', () => {
+  b.race(b).fork(noop, noop);
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/fluture.js
+++ b/fluture.js
@@ -949,7 +949,7 @@
         rej(reason);
       }, function Future$parallel$fork$res(value){
         out[j] = value;
-        ok += 1;
+        ok = ok + 1;
         if(i < _this._length) run(_this._futures[i], i++, c);
         else if(ok === _this._length) res(out);
       });

--- a/fluture.js
+++ b/fluture.js
@@ -735,11 +735,15 @@
     return cancel;
   }
 
-  CachedFuture.prototype.toString = function CachedFuture$toString(){
+  CachedFuture.prototype.inspect = function CachedFuture$inspect(){
     const repr = this._state === 3
       ? show(this._value)
       : `<${this.getState()}>` + (this._state === 2 ? ` ${this._value}` : '');
     return `Future { ${repr} }`;
+  }
+
+  CachedFuture.prototype.toString = function CachedFuture$toString(){
+    return `${this._pure.toString()}.cache()`;
   }
 
   //----------

--- a/fluture.js
+++ b/fluture.js
@@ -198,21 +198,9 @@
     );
   }
 
-  function check$recur(it, f){
-    if(!isFuture(it)) error$invalidContext('Future#recur', it);
-    if(!isFunction(f)) error$invalidArgument('Future#recur', 0, 'be a function', f);
-  }
-
   function check$chain$f(m, f, x){
     if(!isFuture(m)) throw new TypeError(
       'Future#chain expects the function its given to return a Future'
-      + `\n  Actual: ${show(m)}\n  From calling: ${showf(f)}\n  With: ${show(x)}`
-    );
-  }
-
-  function check$recur$f(m, f, x){
-    if(!isFuture(m)) throw new TypeError(
-      'Future#recur expects the function its given to return a Future'
       + `\n  Actual: ${show(m)}\n  From calling: ${showf(f)}\n  With: ${show(x)}`
     );
   }
@@ -405,18 +393,6 @@
     return new FutureChain(this, f);
   }
 
-  function Future$recur(f){
-    check$recur(this, f);
-    const _this = this;
-    return new UnsafeFuture(function Future$chain$fork(rej, res){
-      return _this._f(rej, function Future$chain$res(x){
-        const m = f(x);
-        check$recur$f(m, f, x);
-        m._f(rej, res);
-      });
-    });
-  }
-
   function Future$chainRej(f){
     check$chainRej(this, f);
     const _this = this;
@@ -583,7 +559,6 @@
     [FL.chainRec]: Future$chainRec,
     [FL.chain]: Future$chain,
     chain: Future$chain,
-    recur: Future$recur,
     chainRej: Future$chainRej,
     [FL.map]: Future$map,
     map: Future$map,

--- a/fluture.js
+++ b/fluture.js
@@ -574,24 +574,30 @@
   };
 
   Future.encase = function Future$encase(f, x){
+    if(arguments.length === 1) return unaryPartial(Future$encase, f);
     check$encase(f);
-    if(arguments.length === 1) return unaryPartial(Future.encase, f);
     return new FutureEncase(f, x);
   };
 
   Future.encase2 = function Future$encase2(f, x, y){
-    check$encase2(f);
-    if(arguments.length === 1) return unaryPartial(Future.encase2, f);
-    if(arguments.length === 2) return binaryPartial(Future.encase2, f, x);
-    return new FutureEncase(f, x, y);
+    switch(arguments.length){
+      case 1: return unaryPartial(Future$encase2, f);
+      case 2: return binaryPartial(Future$encase2, f, x);
+      default:
+        check$encase2(f);
+        return new FutureEncase(f, x, y);
+    }
   };
 
   Future.encase3 = function Future$encase3(f, x, y, z){
-    check$encase3(f);
-    if(arguments.length === 1) return unaryPartial(Future.encase3, f);
-    if(arguments.length === 2) return binaryPartial(Future.encase3, f, x);
-    if(arguments.length === 3) return ternaryPartial(Future.encase3, f, x, y);
-    return new FutureEncase(f, x, y, z);
+    switch(arguments.length){
+      case 1: return unaryPartial(Future$encase3, f);
+      case 2: return binaryPartial(Future$encase3, f, x);
+      case 3: return ternaryPartial(Future$encase3, f, x, y);
+      default:
+        check$encase3(f);
+        return new FutureEncase(f, x, y, z);
+    }
   };
 
   Future.node = function Future$node(f){

--- a/fluture.js
+++ b/fluture.js
@@ -426,8 +426,8 @@
     });
   }
 
-  function Future$toString(){
-    return `Future(${this._f.toString()})`;
+  function Future$inspect(){
+    return this.toString();
   }
 
   function Future$race(m){
@@ -547,8 +547,7 @@
     [FL.ap]: Future$ap,
     ap: Future$ap,
     swap: Future$swap,
-    toString: Future$toString,
-    inspect: Future$toString,
+    inspect: Future$inspect,
     race: Future$race,
     or: Future$or,
     fold: Future$fold,
@@ -761,8 +760,7 @@
     return cancel;
   }
 
-  CachedFuture.prototype.toString =
-  CachedFuture.prototype.inspect = function CachedFuture$toString(){
+  CachedFuture.prototype.toString = function CachedFuture$toString(){
     const repr = this._state === 3
       ? show(this._value)
       : `<${this.getState()}>` + (this._state === 2 ? ` ${this._value}` : '');

--- a/fluture.js
+++ b/fluture.js
@@ -1074,7 +1074,7 @@
       check$chain$f(m, _this._chainer, x);
       cancel = m._f(rej, res);
     });
-    return cancel ? cancel : (cancel = r, function FutureChain$fork$cancel(){ cancel() });
+    return cancel || (cancel = r, function FutureChain$fork$cancel(){ cancel() });
   }
 
   FutureChain.prototype.toString = function FutureChain$toString(){
@@ -1098,7 +1098,7 @@
       check$chainRej$f(m, _this._chainer, x);
       cancel = m._f(rej, res);
     }, res);
-    return cancel ? cancel : (cancel = r, function FutureChainRej$fork$cancel(){ cancel() });
+    return cancel || (cancel = r, function FutureChainRej$fork$cancel(){ cancel() });
   }
 
   FutureChainRej.prototype.toString = function FutureChainRej$toString(){
@@ -1342,7 +1342,7 @@
     }, function FutureFinally$fork$res(x){
       cancel = _this._right._f(rej, function FutureFinally$fork$res$res(){ res(x) });
     });
-    return cancel ? cancel : (cancel = r, function FutureFinally$fork$cancel(){ cancel() });
+    return cancel || (cancel = r, function FutureFinally$fork$cancel(){ cancel() });
   }
 
   FutureFinally.prototype.toString = function FutureFinally$toString(){

--- a/fluture.js
+++ b/fluture.js
@@ -439,10 +439,7 @@
 
   function Future$fold(f, g){
     check$fold(this, f, g);
-    const _this = this;
-    return new UnsafeFuture(function Future$fold$fork(rej, res){
-      return _this._f(e => res(f(e)), x => res(g(x)));
-    });
+    return new FutureFold(this, f, g);
   }
 
   function Future$hook(dispose, consume){
@@ -970,6 +967,29 @@
 
   FutureOr.prototype.toString = function FutureOr$toString(){
     return `${this._left.toString()}.or(${this._right.toString()})`;
+  }
+
+  //----------
+
+  function FutureFold(parent, lfold, rfold){
+    this._parent = parent;
+    this._lfold = lfold;
+    this._rfold = rfold;
+  }
+
+  FutureFold.prototype = Object.create(Future.prototype);
+
+  FutureFold.prototype._f = function FutureFold$fork(rej, res){
+    const _this = this;
+    return _this._parent._f(function FutureFold$fork$rej(x){
+      res(_this._lfold(x));
+    }, function FutureFold$fork$res(x){
+      res(_this._rfold(x));
+    });
+  }
+
+  FutureFold.prototype.toString = function FutureFold$toString(){
+    return `${this._parent.toString()}.fold(${showf(this._lfold)}, ${showf(this._rfold)})`;
   }
 
   /////////////////

--- a/fluture.js
+++ b/fluture.js
@@ -685,6 +685,11 @@
 
   //----------
 
+  //data Timing = Undetermined | Synchronous | Asynchronous
+  const Undetermined = 0;
+  const Synchronous = 1;
+  const Asynchronous = 2;
+
   function ChainRec(iterate, init){
     this._iterate = iterate;
     this._init = init;
@@ -696,26 +701,24 @@
     const _this = this;
     let cancel = noop, i = 0;
     (function Future$chainRec$recur(state){
-      let isSync = null;
+      let timing = Undetermined;
       function Future$chainRec$res(it){
         check$chainRec$it(it, i);
         i = i + 1;
-        if(isSync === null){
-          isSync = true;
+        if(timing === Undetermined){
+          timing = Synchronous;
           state = it;
         }else{
           Future$chainRec$recur(it);
         }
       }
       while(!state.done){
-        isSync = null;
+        timing = Undetermined;
         const m = _this._iterate(Next, Done, state.value);
         check$chainRec$f(m, _this._iterate, i, state.value);
         cancel = m._f(rej, Future$chainRec$res);
-        if(isSync === true){
-          continue;
-        }else{
-          isSync = false;
+        if(timing !== Synchronous){
+          timing = Asynchronous;
           return;
         }
       }

--- a/fluture.js
+++ b/fluture.js
@@ -761,7 +761,7 @@
     return function CachedFuture$removeFromQueue(){
       if(_this._state > 1) return;
       _this._queue[i] = undefined;
-      _this._queued = this._queued - 1;
+      _this._queued = _this._queued - 1;
       if(_this._queued === 0) _this.reset();
     };
   }
@@ -788,6 +788,15 @@
     this._drainQueue();
   }
 
+  CachedFuture.prototype.run = function CachedFuture$run(){
+    const _this = this;
+    _this._state = 1;
+    _this._cancel = _this._pure._f(
+      function CachedFuture$fork$rej(x){ _this.reject(x) },
+      function CachedFuture$fork$res(x){ _this.resolve(x) }
+    );
+  }
+
   CachedFuture.prototype.reset = function CachedFuture$reset(){
     this._cancel();
     this._cancel = noop;
@@ -806,15 +815,9 @@
     let cancel = noop;
     switch(_this._state){
       case 1: cancel = _this._addToQueue(rej, res); break;
-      case 2: rej(_this._value); cancel = noop; break;
-      case 3: res(_this._value); cancel = noop; break;
-      default:
-        _this._state = 1;
-        _this._addToQueue(rej, res);
-        _this._cancel = _this._pure._f(
-          function CachedFuture$fork$rej(x){ _this.reject(x) },
-          function CachedFuture$fork$res(x){ _this.resolve(x) }
-        );
+      case 2: rej(_this._value); break;
+      case 3: res(_this._value); break;
+      default: cancel = _this._addToQueue(rej, res); _this.run();
     }
     return cancel;
   }

--- a/fluture.js
+++ b/fluture.js
@@ -41,7 +41,7 @@
   }
 
   function isFuture(m){
-    return (m instanceof Future) || Boolean(m) && m['@@type'] === TYPEOF_FUTURE;
+    return m instanceof Future || Boolean(m) && m['@@type'] === TYPEOF_FUTURE;
   }
 
   function isFunction(f){

--- a/fluture.js
+++ b/fluture.js
@@ -420,10 +420,7 @@
 
   function Future$swap(){
     check$swap(this);
-    const _this = this;
-    return new UnsafeFuture(function Future$swap$fork(rej, res){
-      return _this._f(res, rej);
-    });
+    return new FutureSwap(this);
   }
 
   function Future$inspect(){
@@ -922,6 +919,22 @@
 
   FutureAp.prototype.toString = function FutureAp$toString(){
     return `${this._mval.toString()}.ap(${this._mfunc.toString()})`;
+  }
+
+  //----------
+
+  function FutureSwap(parent){
+    this._parent = parent;
+  }
+
+  FutureSwap.prototype = Object.create(Future.prototype);
+
+  FutureSwap.prototype._f = function FutureSwap$fork(rej, res){
+    return this._parent._f(res, rej);
+  }
+
+  FutureSwap.prototype.toString = function FutureSwap$toString(){
+    return `${this._parent.toString()}.swap()`;
   }
 
   /////////////////

--- a/fluture.js
+++ b/fluture.js
@@ -410,14 +410,7 @@
 
   function Future$bimap(f, g){
     check$bimap(this, f, g);
-    const _this = this;
-    return new UnsafeFuture(function Future$bimap$fork(rej, res){
-      return _this._f(function Future$bimap$rej(x){
-        rej(f(x));
-      }, function Future$bimap$res(x){
-        res(g(x));
-      });
-    });
+    return new FutureBimap(this, f, g);
   }
 
   function Future$ap(m){
@@ -879,6 +872,29 @@
 
   FutureMapRej.prototype.toString = function FutureMapRej$toString(){
     return `${this._parent.toString()}.mapRej(${showf(this._mapper)})`;
+  }
+
+  //----------
+
+  function FutureBimap(parent, lmapper, rmapper){
+    this._parent = parent;
+    this._lmapper = lmapper;
+    this._rmapper = rmapper;
+  }
+
+  FutureBimap.prototype = Object.create(Future.prototype);
+
+  FutureBimap.prototype._f = function FutureBimap$fork(rej, res){
+    const _this = this;
+    return _this._parent._f(function FutureBimap$fork$rej(x){
+      rej(_this._lmapper(x));
+    }, function FutureBimap$fork$res(x){
+      res(_this._rmapper(x));
+    });
+  }
+
+  FutureBimap.prototype.toString = function FutureBimap$toString(){
+    return `${this._parent.toString()}.bimap(${showf(this._lmapper)}, ${showf(this._rmapper)})`;
   }
 
   //----------

--- a/fluture.js
+++ b/fluture.js
@@ -405,12 +405,7 @@
 
   function Future$mapRej(f){
     check$mapRej(this, f);
-    const _this = this;
-    return new UnsafeFuture(function Future$mapRej$fork(rej, res){
-      return _this._f(function Future$mapRej$rej(x){
-        rej(f(x));
-      }, res);
-    });
+    return new FutureMapRej(this, f);
   }
 
   function Future$bimap(f, g){
@@ -864,6 +859,26 @@
 
   FutureMap.prototype.toString = function FutureMap$toString(){
     return `${this._parent.toString()}.map(${showf(this._mapper)})`;
+  }
+
+  //----------
+
+  function FutureMapRej(parent, mapper){
+    this._parent = parent;
+    this._mapper = mapper;
+  }
+
+  FutureMapRej.prototype = Object.create(Future.prototype);
+
+  FutureMapRej.prototype._f = function FutureMapRej$fork(rej, res){
+    const _this = this;
+    return _this._parent._f(function FutureMapRej$fork$rej(x){
+      rej(_this._mapper(x));
+    }, res);
+  }
+
+  FutureMapRej.prototype.toString = function FutureMapRej$toString(){
+    return `${this._parent.toString()}.mapRej(${showf(this._mapper)})`;
   }
 
   //----------

--- a/fluture.js
+++ b/fluture.js
@@ -395,16 +395,7 @@
 
   function Future$chainRej(f){
     check$chainRej(this, f);
-    const _this = this;
-    return new UnsafeFuture(function Future$chainRej$fork(rej, res){
-      let cancel;
-      const r = _this._f(function Future$chainRej$rej(x){
-        const m = f(x);
-        check$chainRej$f(m, f, x);
-        cancel = m._f(rej, res);
-      }, res);
-      return cancel ? cancel : (cancel = r, function Future$chainRej$cancel(){ cancel() });
-    });
+    return new FutureChainRej(this, f);
   }
 
   function Future$map(f){
@@ -829,6 +820,30 @@
 
   FutureChain.prototype.toString = function FutureChain$toString(){
     return `${this._parent.toString()}.chain(${showf(this._chainer)})`;
+  }
+
+  //----------
+
+  function FutureChainRej(parent, chainer){
+    this._parent = parent;
+    this._chainer = chainer;
+  }
+
+  FutureChainRej.prototype = Object.create(Future.prototype);
+
+  FutureChainRej.prototype._f = function FutureChainRej$fork(rej, res){
+    const _this = this;
+    let cancel;
+    const r = _this._parent._f(function FutureChainRej$fork$rej(x){
+      const m = _this._chainer(x);
+      check$chainRej$f(m, _this._chainer, x);
+      cancel = m._f(rej, res);
+    }, res);
+    return cancel ? cancel : (cancel = r, function FutureChainRej$fork$cancel(){ cancel() });
+  }
+
+  FutureChainRej.prototype.toString = function FutureChainRej$toString(){
+    return `${this._parent.toString()}.chainRej(${showf(this._chainer)})`;
   }
 
   //----------

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "istanbul": "^0.4.2",
     "jsverify": "^0.7.1",
     "lazy-either": "^1.0.3",
+    "lodash.curry": "^4.1.1",
     "markdown-toc": "^0.12.6",
     "mocha": "^3.0.2",
     "nsp": "^2.2.0",

--- a/scripts/test-opt.js
+++ b/scripts/test-opt.js
@@ -22,7 +22,7 @@ console.log('--- map chain ap fork ---');
 
 Future.of(1)
 .map(x => x + 1)
-.chain(x => Future.of(f => f(x + 1)))
+.chain(x => Future.of(x + 1))
 .ap(Future.of(x => x + 1))
 .fork(noop, noop);
 
@@ -40,7 +40,7 @@ printStatus(m.fork);
 
 Future.of(1)
 .map(x => x + 1)
-.chain(x => Future.of(f => f(x + 1)))
+.chain(x => Future.of(x + 1))
 .ap(Future.of(x => x + 1))
 .fork(noop, noop);
 

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -723,58 +723,6 @@ describe('Future', () => {
 
   });
 
-  describe('#recur()', () => {
-
-    it('throws when invoked out of context', () => {
-      const f = () => immediateRes.recur.call(null, noop);
-      expect(f).to.throw(TypeError, /Future/);
-    });
-
-    it('throws TypeError when not given a function', () => {
-      const fs = xs.map(x => () => immediateRes.recur(x));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('throws TypeError when the given function does not return Future', () => {
-      const fs = xs.map(x => () => immediateRes.recur(() => x).fork(noop, noop));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('calls the given function with the inner of the Future', () => {
-      immediateRes.recur(x => (expect(x).to.equal(1), Future.of(null))).fork(noop, noop);
-    });
-
-    it('returns a Future with an inner equal to the returned Future', () => {
-      const actual = immediateRes.recur(() => Future.of(2));
-      return assertResolved(actual, 2);
-    });
-
-    it('maintains rejected state', () => {
-      const actual = immediateRej.recur(() => immediateRes);
-      return assertRejected(actual, 1);
-    });
-
-    it('assumes rejected state', () => {
-      const actual = immediateRes.recur(() => immediateRej);
-      return assertRejected(actual, 1);
-    });
-
-    it('does not recur after being cancelled on the main branch', done => {
-      delayedRes.recur(failRes).fork(failRej, failRes)();
-      setTimeout(done, 25);
-    });
-
-    it('does not reject after being cancelled on the main branch', done => {
-      delayedRej.recur(failRes).fork(failRej, failRes)();
-      setTimeout(done, 25);
-    });
-
-    it('does not cancel the off-branch', done => {
-      immediateRes.recur(_ => delayedRes).fork(failRej, _ => done())();
-    });
-
-  });
-
   describe('#chainRej()', () => {
 
     it('throws when invoked out of context', () => {

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -446,6 +446,24 @@ describe('Constructors', () => {
       setTimeout(cancel, 20);
     });
 
+    it('cancels only running Futures when cancelled', done => {
+      let i = 0, j = 0;
+      const m = Future((rej, res) => {
+        const x = setTimeout(x => {j += 1; res(x)}, 20, 1);
+        return () => {
+          i += 1
+          clearTimeout(x);
+        };
+      });
+      const cancel = Future.parallel(2, [m, m, m, m]).fork(failRej, failRes);
+      setTimeout(() => {
+        cancel();
+        expect(i).to.equal(2);
+        expect(j).to.equal(2);
+        done();
+      }, 30);
+    })
+
     it('does not resolve after being cancelled', done => {
       const cancel = Future.parallel(1, [delayedRes, delayedRes]).fork(failRej, failRes);
       setTimeout(cancel, 10);

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -250,8 +250,8 @@ describe('Constructors', () => {
     });
 
     it('has custom toString and inspect', () => {
-      const m = Future.encase((a) => (a), 1);
-      const s = 'Future.encase((a) => (a), 1)';
+      const m = Future.encase(a => a, 1);
+      const s = 'Future.encase(a => a, 1)';
       expect(m.toString()).to.equal(s);
       expect(m.inspect()).to.equal(s);
     });
@@ -291,8 +291,8 @@ describe('Constructors', () => {
     });
 
     it('has custom toString and inspect', () => {
-      const m = Future.encase2((a, b) => (b), 1, 2);
-      const s = 'Future.encase2((a, b) => (b), 1, 2)';
+      const m = Future.encase2((a, b) => b, 1, 2);
+      const s = 'Future.encase2((a, b) => b, 1, 2)';
       expect(m.toString()).to.equal(s);
       expect(m.inspect()).to.equal(s);
     });
@@ -337,8 +337,8 @@ describe('Constructors', () => {
     });
 
     it('has custom toString and inspect', () => {
-      const m = Future.encase3((a, b, c) => (c), 1, 2, 3);
-      const s = 'Future.encase3((a, b, c) => (c), 1, 2, 3)';
+      const m = Future.encase3((a, b, c) => c, 1, 2, 3);
+      const s = 'Future.encase3((a, b, c) => c, 1, 2, 3)';
       expect(m.toString()).to.equal(s);
       expect(m.inspect()).to.equal(s);
     });

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -1179,6 +1179,13 @@ describe('Future', () => {
       setTimeout(done, 25);
     });
 
+    it('immediately runs and cancels the disposal Future when cancelled after acquire', done => {
+      const cancel = immediateRes
+        .hook(_ => Future(() => () => done()), () => delayedRes)
+        .fork(failRej, failRes);
+      setTimeout(cancel, 10);
+    });
+
   });
 
   describe('#finally()', () => {


### PR DESCRIPTION
This refactors the code from using closure capturing to using class properties. This way of working was inspired by the [FunTask source](https://github.com/rpominov/fun-task/tree/master/src) and has several benefits:

**Performance**

* `chainRec` 50% faster
* `cache` 100% faster
* `race` - 300% faster
* `parallel` - 30% faster
* All other functions - 10-20% faster

**Introspectivity**

Every type of Future can now have its own `toString` function associated with it. Casting a Future to String now shows something much closer to what the user originally typed.
This new introspective nature also allows for the creation of a more informative [sanctuary-def](https://github.com/sanctuary-js/sanctuary-def) type - something for another pull-request.

**Other fixes**

Besides refactoring, I also corrected some minor mis-behaviors:

* The cancellation function of cached Futures no longer unsubscribes all listeners. Instead only the listeners for the specific call to `fork` which created the called `cancel` function will be unsubscribed. If there are other listeners left, the Future will keep running.
* Fix some broken benchmarks.
* When [`Future.or`](/Avaq/Fluture#or), [`Future.race`](/Avaq/Fluture#race), or [`Future.parallel`](/Avaq/Fluture#parallel) settles, all remaining running Futures will be cancelled.
* Now when a [hooked Future](/Avaq/Fluture#hook) is cancelled, its disposal Future is still executed, and immediately cancelled as well. This creates a much better chance for resources to be disposed, and allows a developer to forcefully get rid of resources in a much more logical place: The disposal cancellation function instead of the consumption cancellation function.
* [`Future.recur`](/Avaq/Fluture#recur) was removed in favor of [`Future.chainRec`](/Avaq/Fluture#chainRec)

These changes are backwards-incompatible, and will be released under a new major version.