### PR TITLE
Replace Future#promise() with Promises/A+ compatible Future#then()

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "mocha": "^3.0.2",
     "nsp": "^2.2.0",
     "pacta": "^0.9.0",
+    "promises-aplus-tests": "^2.1.2",
     "ramda": "^0.22.1",
     "ramda-fantasy": "^0.7.0",
     "rimraf": "^2.4.3",

--- a/test/fluture.test.js
+++ b/test/fluture.test.js
@@ -1447,30 +1447,22 @@ describe('Future', () => {
 
   });
 
-  describe('#promise()', () => {
+  describe('#then()', () => {
 
     it('throws when invoked out of context', () => {
-      const f = () => Future.of(1).promise.call(null);
+      const f = () => Future.of(1).then.call(null);
       expect(f).to.throw(TypeError, /Future/);
     });
 
-    it('returns a Promise', () => {
-      const actual = Future.of(1).promise();
-      expect(actual).to.be.an.instanceof(Promise);
+    it('returns a Future', () => {
+      const actual = Future.of(1).then();
+      expect(actual).to.be.an.instanceof(Future);
     });
 
-    it('resolves if the Future resolves', done => {
-      Future.of(1).promise().then(
-        x => (expect(x).to.equal(1), done()),
-        done
-      );
-    });
-
-    it('rejects if the Future rejects', done => {
-      Future.reject(1).promise().then(
-        () => done(new Error('It resolved')),
-        x => (expect(x).to.equal(1), done())
-      );
+    it('has custom toString', () => {
+      const m = Future.of(1).then(x => x);
+      const s = 'Future.of(1).then(x => x, undefined).cache()';
+      expect(m.toString()).to.equal(s);
     });
 
   });
@@ -1826,6 +1818,17 @@ describe('Compliance', function(){
 
   });
 
+  describe('to Promises/A+', () => {
+    require('promises-aplus-tests').mocha({
+      resolved: Future.of,
+      rejected: Future.reject,
+      deferred: () => {
+        const m = Future.cache(Future(noop));
+        return {promise: m, reject: x => m.reject(x), resolve: x => m.resolve(x)};
+      }
+    });
+  });
+
 });
 
 describe('Dispatchers', () => {
@@ -2092,19 +2095,6 @@ describe('Dispatchers', () => {
 
     it('dispatches to #value', done => {
       Future.value(x => (expect(x).to.equal(1), done()))(Future.of(1));
-    });
-
-  });
-
-  describe('.promise()', () => {
-
-    it('throws when not given a Future', () => {
-      const f = () => Future.promise(1);
-      expect(f).to.throw(TypeError, /Future/);
-    });
-
-    it('dispatches to #promise', done => {
-      Future.promise(Future.of(null)).then(done);
     });
 
   });


### PR DESCRIPTION
So this might be an interesting topic for conversation. Using the new `CachedFuture` class I created while working on #34, I was able to create a fully Promises/A+ compliant `then` method. Essentially **turning Fluture into a Promise library**! o.0

I think the library might benefit from having this. Particularly because `fork` is not standardized. Though I'm very eager to hear peoples opinions. Check out the diff in the readme to learn about how I advice the feature to be used.