### PR TITLE
Depend on Sanctuary Type Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,14 @@ A list of all types used within the signatures follows:
   arguments. This includes instances of Fluture, instances of Task from
   [`data.task`][10] or instances of Future from [`ramda-fantasy`][11].
 - **Future** - Instances of Future provided by Fluture.
-- **Functor** - Values which conform to the [Fantasy Land Functor specification][12].
-- **Bifunctor** - Values which conform to the [Fantasy Land Bifunctor specification][24].
-- **Chain** - Values which conform to the [Fantasy Land Chain specification][13].
-- **Apply** - Values which conform to the [Fantasy Land Apply specification][14].
+- **Functor** - Values which conform to the [Fantasy Land Functor specification][12]
+  as determined by [Sanctuary Type Classes][27].
+- **Bifunctor** - Values which conform to the [Fantasy Land Bifunctor specification][24]
+  as determined by [Sanctuary Type Classes][28].
+- **Chain** - Values which conform to the [Fantasy Land Chain specification][13]
+  as determined by [Sanctuary Type Classes][29].
+- **Apply** - Values which conform to the [Fantasy Land Apply specification][14]
+  as determined by [Sanctuary Type Classes][30].
 - **Iterator** - Objects with `next`-methods which conform to the [Iterator protocol][18].
 - **Iteration** - `{done, value}`-Objects as defined by the [Iterator protocol][18].
 - **Next** - An incomplete (`{done: false}`) Iteration.
@@ -842,3 +846,7 @@ means butterfly in Romanian; A creature you might expect to see in Fantasy Land.
 [24]: https://github.com/fantasyland/fantasy-land#bifunctor
 [25]: https://github.com/rpominov/static-land
 [26]: https://github.com/fantasyland/fantasy-land#chainrec
+[27]: https://github.com/sanctuary-js/sanctuary-type-classes#Functor
+[28]: https://github.com/sanctuary-js/sanctuary-type-classes#Bifunctor
+[29]: https://github.com/sanctuary-js/sanctuary-type-classes#Chain
+[30]: https://github.com/sanctuary-js/sanctuary-type-classes#Apply

--- a/bench/static.js
+++ b/bench/static.js
@@ -1,0 +1,38 @@
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Future = require('..');
+
+const f = x => x + 1;
+const m1 = Future.of(1);
+const mf = Future.of(f);
+
+suite.add('ap(m1)', () => {
+  Future.ap(m1);
+});
+
+suite.add('ap(m1)(mf)', () => {
+  Future.ap(m1)(mf);
+});
+
+suite.add('ap(m1, mf)', () => {
+  Future.ap(m1, mf);
+});
+
+suite.add('bimap(f)', () => {
+  Future.bimap(f);
+});
+
+suite.add('bimap(f)(f)', () => {
+  Future.bimap(f)(f);
+});
+
+suite.add('bimap(f)(f)(m1)', () => {
+  Future.bimap(f)(f)(m1);
+});
+
+suite.add('bimap(f, f, m1)', () => {
+  Future.bimap(f, f, m1);
+});
+
+suite.on('complete', require('./_print'))
+suite.run()

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "sequential"
   ],
   "dependencies": {
-    "inspect-f": "^1.1.0"
+    "inspect-f": "^1.1.0",
+    "sanctuary-type-classes": "^0.1.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",


### PR DESCRIPTION
* Replaces `show` with `Z.toString`
* Replaces `ap`, `map`, `bimap` and `chain` with curried `Z` equivalents

Fixes part of #4 