### PR TITLE
sanctuary-type-classes@^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "inspect-f": "^1.1.0",
-    "sanctuary-type-classes": "^0.3.0"
+    "sanctuary-type-classes": "^1.0.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",


### PR DESCRIPTION
https://github.com/sanctuary-js/sanctuary-type-classes/compare/v0.3.0...v1.0.0

v1.0.0 is equivalent to v0.3.1. I released the former upon your suggestion, @Avaq. The library is solid.
