### PR TITLE
Add es5 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["latest"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ coverage/
 # Test file - who doesn't have a test file?
 test.js
 
+# Transpiled ES5 file - for publishing only
+es5.js
+
 # Heap snapshots
 *.heapsnapshot

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more information:
 
 ## Usage
 
-> `npm install --save fluture` <sup>Requires a node 4.0.0 compatible environment</sup>
+> `npm install --save fluture`
 
 ```js
 const fs = require('fs');
@@ -47,6 +47,8 @@ getPackageName('package.json')
 .fork(console.error, console.log);
 //> "fluture"
 ```
+
+For front-end applications and node <v4, please use `require('fluture/es5')`.
 
 ## Table of contents
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,19 @@
   "version": "4.2.0",
   "description": "FantasyLand compliant (monadic) alternative to Promises",
   "main": "fluture.js",
+  "files": [
+    "es5.js"
+  ],
   "repository": "https://github.com/Avaq/fluture.git",
   "scripts": {
+    "build": "babel fluture.js -o es5.js",
     "clean": "rimraf npm-debug.log coverage",
     "lint": "eslint fluture.js test",
     "lint:readme": "remark --no-stdout --frail -u remark-validate-links README.md",
     "postcheckout": "npm install",
     "postmerge": "npm install",
     "precommit": "npm run lint && npm run lint:readme && npm run test:unit",
+    "prepublish": "npm run build",
     "release": "npm outdated --long && xyz --edit --repo git@github.com:Avaq/Fluture.git --tag 'X.Y.Z' --increment",
     "toc": "node scripts/toc.js",
     "test": "npm run test:all && codecov",
@@ -29,9 +34,6 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "files": [
-    "fluture.js"
-  ],
   "keywords": [
     "algebraic",
     "async",
@@ -52,10 +54,12 @@
     "sequential"
   ],
   "dependencies": {
-    "inspect-f": "^1.1.0",
+    "inspect-f": "^1.2.0",
     "sanctuary-type-classes": "^2.0.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-preset-latest": "^6.16.0",
     "benchmark": "^2.1.0",
     "chai": "^3.4.0",
     "codecov": "^1.0.1",


### PR DESCRIPTION
## Problem
When doing uglification for our production app, we ran into problems with UglifyJS2 not supporting ES6.

## Solution
Normally, npm packages are transpiled when published so that users of the packages don't have to worry about their compatibility. I thought it might be best to give users the choice - by default they import ES6 version but optionally can `require('Fluture/es5')` to avoid issues when compiling for production.

Same thing will need to be done for `inspect-f` as it's a dependency for Fluture. In which case, Fluture will need to require ES5 version of `inspect-f`.

Do you think this would be a good way to go?
