### PR TITLE
Deprecate fromForkable and isForkable (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ For front-end applications and node <v4, please use `require('fluture/es5')`.
     * [rejectAfter](#rejectafter)
     * [try](#try)
     * [encase](#encase)
-    * [fromForkable](#fromforkable)
     * [fromPromise](#frompromise)
     * [node](#node)
     * [chainRec](#chainrec)
@@ -93,7 +92,6 @@ For front-end applications and node <v4, please use `require('fluture/es5')`.
     * [parallel](#parallel)
   1. [Utility functions](#utility-functions)
     * [isFuture](#isfuture)
-    * [isForkable](#isforkable)
     * [cache](#cache)
     * [do](#do)
   1. [Sanctuary](#sanctuary)
@@ -123,9 +121,6 @@ with a `#` refer to functions on the prototype.
 
 A list of all types used within the signatures follows:
 
-- **Forkable** - Any Object with a `fork` method that takes at least two
-  arguments. This includes instances of Fluture, instances of Task from
-  [`data.task`][10] or instances of Future from [`ramda-fantasy`][11].
 - **Future** - Instances of Future provided by Fluture.
 - **Promise** - Values which conform to the [Promises/A+ specification][33].
 - **Functor** - Values which conform to the [Fantasy Land Functor specification][12]
@@ -253,16 +248,6 @@ safeJsonParse(data).fork(console.error, console.log)
 
 Furthermore; `encase2` and `encase3` are binary and ternary versions of
 `encase`, applying two or three arguments to the given function respectively.
-
-#### fromForkable
-##### `.fromForkable :: Forkable a b -> Future a b`
-
-Cast any [Forkable](#type-signatures) to a [Future](#type-signatures).
-
-```js
-Future.fromForkable(require('data.task').of('hello')).value(console.log);
-//> "hello"
-```
 
 #### fromPromise
 ##### `.fromPromise :: (a -> Promise e r) -> a -> Future e r`
@@ -787,11 +772,6 @@ const m2 = Future2(noop);
 Future1.isFuture(m2) !== (m2 instanceof Future1);
 ```
 
-#### isForkable
-##### `.isForkable :: a -> Boolean`
-
-Returns true for [Forkables](#type-signatures) and false for everything else.
-
 #### cache
 ##### `.cache :: Future a b -> Future a b`
 
@@ -949,8 +929,6 @@ Credits for the logo go to [Erik Fuente][34].
 [7]:  http://sanctuary.js.org/#either-type
 [8]:  https://github.com/fantasyland/fantasy-land/pull/124
 [9]:  https://drboolean.gitbooks.io/mostly-adequate-guide/content/ch7.html
-[10]: https://github.com/folktale/data.task
-[11]: https://github.com/ramda/ramda-fantasy
 [12]: https://github.com/fantasyland/fantasy-land#functor
 [13]: https://github.com/fantasyland/fantasy-land#chain
 [14]: https://github.com/fantasyland/fantasy-land#apply

--- a/fluture.js
+++ b/fluture.js
@@ -40,6 +40,7 @@
   };
 
   function isForkable(m){
+    deprecate('Future.isForkable() is deprecated');
     return Boolean(m) && typeof m.fork === 'function' && m.fork.length >= 2;
   }
 
@@ -273,7 +274,6 @@
   Future.chainRec = Future$chainRec;
   Future.Future = Future;
   Future.isFuture = isFuture;
-  Future.isForkable = isForkable;
 
   function ap$mval(mval, mfunc){
     if(!Z.Apply.test(mfunc)) invalidArgument('Future.ap', 1, 'be an Apply', mfunc);
@@ -375,8 +375,13 @@
   };
 
   Future.cast = function Future$cast(m){
-    deprecate('Future.cast has been renamed to Future.fromForkable and will soon be removed');
-    return Future.fromForkable(m);
+    deprecate('Future.cast() is deprecated. Please use Future((l, r) => {m.fork(l, r)})');
+    return new SafeFuture((l, r) => void m.fork(l, r));
+  };
+
+  Future.fromForkable = function Future$fromForkable(m){
+    deprecate('Future.fromForkable() is deprecated. Please use Future((l, r) => {m.fork(l, r)})');
+    return new SafeFuture((l, r) => void m.fork(l, r));
   };
 
   Future.try = function Future$try(f){
@@ -411,11 +416,6 @@
         if(!isTernary(f)) invalidArgument('Future.encase3', 0, 'take three arguments', f);
         return new FutureEncase(f, x, y, z);
     }
-  };
-
-  Future.fromForkable = function Future$fromForkable(f){
-    if(!isForkable(f)) invalidArgument('Future.fromForkable', 0, 'be a forkable', f);
-    return new FutureFromForkable(f);
   };
 
   Future.fromPromise = function Future$fromPromise(f, x){
@@ -1067,33 +1067,6 @@
 
   //----------
 
-  function FutureFromForkable(forkable){
-    this._forkable = forkable;
-  }
-
-  FutureFromForkable.prototype = Object.create(Future.prototype);
-
-  FutureFromForkable.prototype._f = function FutureFromForkable$fork(rej, res){
-    let pending = true;
-    return this._forkable.fork(function FutureFromForkable$fork$rej(reason){
-      if(pending){
-        pending = false;
-        rej(reason);
-      }
-    }, function FutureFromForkable$res(value){
-      if(pending){
-        pending = false;
-        res(value);
-      }
-    });
-  };
-
-  FutureFromForkable.prototype.toString = function FutureFromForkable$toString(){
-    return `Future.fromForkable(${show(this._forkable)})`;
-  };
-
-  //----------
-
   function FutureTry(fn){
     this._fn = fn;
   }
@@ -1597,7 +1570,6 @@
     FutureDo,
     FutureTry,
     FutureEncase,
-    FutureFromForkable,
     FutureFromPromise,
     FutureChain,
     FutureChainRej,

--- a/test/5.future-cast.test.js
+++ b/test/5.future-cast.test.js
@@ -2,12 +2,37 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureFromForkable = Future.classes.FutureFromForkable;
+const SafeFuture = Future.classes.SafeFuture;
+const U = require('./util');
 
 describe('Future.cast()', () => {
 
-  it('returns an instance of FutureFromForkable', () => {
-    expect(Future.cast(Future.of(1))).to.be.an.instanceof(FutureFromForkable);
+  it('returns an instance of SafeFuture', () => {
+    expect(Future.cast(Future.of(1))).to.be.an.instanceof(SafeFuture);
+  });
+
+  describe('#fork()', () => {
+
+    it('rejects if the Forkable calls the left', () => {
+      const forkable = {fork: (l, r) => (r, l(U.error))};
+      return U.assertRejected(Future.cast(forkable), U.error);
+    });
+
+    it('resolves if the Forkable calls the right', () => {
+      const forkable = {fork: (l, r) => r(1)};
+      return U.assertResolved(Future.cast(forkable), 1);
+    });
+
+    it('ensures no continuations are called after the first resolve', done => {
+      const forkable = {fork: (l, r) => { r(1); r(2); l(3) }};
+      Future.cast(forkable).fork(U.failRej, _ => done());
+    });
+
+    it('ensures no continuations are called after the first reject', done => {
+      const forkable = {fork: (l, r) => { l(1); r(2); l(3) }};
+      Future.cast(forkable).fork(_ => done(), U.failRes);
+    });
+
   });
 
 });

--- a/test/5.future-from-forkable.test.js
+++ b/test/5.future-from-forkable.test.js
@@ -2,86 +2,37 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureFromForkable = Future.classes.FutureFromForkable;
+const SafeFuture = Future.classes.SafeFuture;
 const U = require('./util');
-const F = require('./futures');
-const RamdaFuture = require('ramda-fantasy').Future;
-const DataTask = require('data.task');
 
 describe('Future.fromForkable()', () => {
 
-  it('throws TypeError when not given a Forkable', () => {
-    const xs = [null, {}, {fork: a => a}];
-    const fs = xs.map(x => () => Future.fromForkable(x));
-    fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-  });
-
-  it('returns an instance of FutureFromForkable', () => {
-    expect(Future.fromForkable(Future.of(1))).to.be.an.instanceof(FutureFromForkable);
-  });
-
-});
-
-describe('FutureFromForkable', () => {
-
-  it('extends Future', () => {
-    expect(new FutureFromForkable).to.be.an.instanceof(Future);
+  it('returns an instance of SafeFuture', () => {
+    expect(Future.fromForkable(Future.of(1))).to.be.an.instanceof(SafeFuture);
   });
 
   describe('#fork()', () => {
 
     it('rejects if the Forkable calls the left', () => {
       const forkable = {fork: (l, r) => (r, l(U.error))};
-      return U.assertRejected(new FutureFromForkable(forkable), U.error);
+      return U.assertRejected(Future.fromForkable(forkable), U.error);
     });
 
     it('resolves if the Forkable calls the right', () => {
       const forkable = {fork: (l, r) => r(1)};
-      return U.assertResolved(new FutureFromForkable(forkable), 1);
+      return U.assertResolved(Future.fromForkable(forkable), 1);
     });
 
     it('ensures no continuations are called after the first resolve', done => {
       const forkable = {fork: (l, r) => { r(1); r(2); l(3) }};
-      new FutureFromForkable(forkable).fork(U.failRej, _ => done());
+      Future.fromForkable(forkable).fork(U.failRej, _ => done());
     });
 
     it('ensures no continuations are called after the first reject', done => {
       const forkable = {fork: (l, r) => { l(1); r(2); l(3) }};
-      new FutureFromForkable(forkable).fork(_ => done(), U.failRes);
+      Future.fromForkable(forkable).fork(_ => done(), U.failRes);
     });
 
-    it('preserves cancellation', done => {
-      const m = new FutureFromForkable(F.resolvedSlow);
-      const cancel = m.fork(U.failRej, U.failRes);
-      cancel();
-      setTimeout(done, 25);
-    });
-
-  });
-
-  describe('#toString()', () => {
-
-    it('returns the code to create the FutureFromForkable', () => {
-      const m = new FutureFromForkable(Future.of(1));
-      expect(m.toString()).to.equal('Future.fromForkable(Future.of(1))');
-    });
-
-  });
-
-});
-
-describe('Usage: Future.fromForkable()', () => {
-
-  it('converts Ramda Fantasy Futures', () => {
-    const m = Future.fromForkable(RamdaFuture.of(1));
-    expect(m).to.be.an.instanceof(FutureFromForkable);
-    return U.assertResolved(m, 1);
-  });
-
-  it('converts Data Tasks', () => {
-    const m = Future.fromForkable(DataTask.of(1));
-    expect(m).to.be.an.instanceof(FutureFromForkable);
-    return U.assertResolved(m, 1);
   });
 
 });


### PR DESCRIPTION
I deprecated `cast` in version 4.2, but reinstated it as `fromForkable` in version 4.3 because I had plans to create a second "forkable" type; `Parallel`. The idea was that you would be able to cast back and forth between the two like `Future.fromForkable(Parallel.of(1))` and `Parallel.fromForkable(Future.of(1))`. After some discussion in #44, the API was changed to `par = Parallel(Future.of(1))` and (probably) `Future.seq(par)`.

Since in the new setup, `Parallel` is not a "forkable" and Future remains the only local "forkable", I would like to deprecate `fromForkable` as well, for the same reasons I deprecated `cast` in the first place.

The functions are to be removed in the next major release, and deprecation gives a few weeks head to developers. I expect the usage of the functions to be very limited.