### PR TITLE
Remove custom inspect functions

### DIFF
--- a/fluture.js
+++ b/fluture.js
@@ -251,10 +251,6 @@
     return this._f(rej, res);
   };
 
-  Future.prototype.inspect = function Future$inspect(){
-    return this.toString();
-  };
-
   Future.prototype.value = function Future$value(f){
     if(!isFuture(this)) invalidContext('Future#value', this);
     if(!isFunction(f)) invalidArgument('Future#value', 0, 'be a function', f);
@@ -763,17 +759,6 @@
 
   //----------
 
-  //data State = Cold | Pending | Rejected | Resolved
-  const Cold = 0;
-  const Pending = 1;
-  const Rejected = 2;
-  const Resolved = 3;
-
-  function Queued(rej, res){
-    this[Rejected] = rej;
-    this[Resolved] = res;
-  }
-
   function CachedFuture(pure){
     this._pure = pure;
     this._cancel = noop;
@@ -783,12 +768,15 @@
     this._state = Cold;
   }
 
-  CachedFuture.STATE = {
-    [Cold]: 'cold',
-    [Pending]: 'pending',
-    [Rejected]: 'rejected',
-    [Resolved]: 'resolved'
-  };
+  const Cold = CachedFuture.Cold = 0;
+  const Pending = CachedFuture.Pending = 1;
+  const Rejected = CachedFuture.Rejected = 2;
+  const Resolved = CachedFuture.Resolved = 3;
+
+  function Queued(rej, res){
+    this[Rejected] = rej;
+    this[Resolved] = res;
+  }
 
   CachedFuture.prototype = Object.create(Future.prototype);
 
@@ -862,10 +850,6 @@
     this._state = Cold;
   };
 
-  CachedFuture.prototype.getState = function CachedFuture$getState(){
-    return CachedFuture.STATE[this._state];
-  };
-
   CachedFuture.prototype._f = function CachedFuture$fork(rej, res){
     const _this = this;
     let cancel = noop;
@@ -876,13 +860,6 @@
       default: cancel = _this._addToQueue(rej, res); _this.run();
     }
     return cancel;
-  };
-
-  CachedFuture.prototype.inspect = function CachedFuture$inspect(){
-    const repr = this._state === Resolved
-      ? show(this._value)
-      : `<${this.getState()}>` + (this._state === Rejected ? ` ${show(this._value)}` : '');
-    return `CachedFuture({ ${repr} })`;
   };
 
   CachedFuture.prototype.toString = function CachedFuture$toString(){

--- a/test/1.future.test.js
+++ b/test/1.future.test.js
@@ -493,16 +493,6 @@ describe('Future', () => {
 
   });
 
-  describe('#inspect()', () => {
-
-    it('dispatches to #toString()', () => {
-      const sentinel = {};
-      const exhibit = Future.prototype.inspect.call({toString: () => sentinel});
-      expect(exhibit).to.equal(sentinel);
-    });
-
-  });
-
   describe('#extractLeft()', () => {
 
     it('returns empty array', () => {

--- a/test/5.cached-future.test.js
+++ b/test/5.cached-future.test.js
@@ -121,7 +121,7 @@ describe('CachedFuture', () => {
       const m = Future.cache(Future(U.noop));
       m.reject(1);
       m.resolve(2);
-      expect(m.getState()).to.equal('rejected');
+      expect(m._state).to.equal(CachedFuture.Rejected);
     });
 
   });
@@ -132,7 +132,7 @@ describe('CachedFuture', () => {
       const m = Future.cache(Future(U.noop));
       m.resolve(1);
       m.reject(2);
-      expect(m.getState()).to.equal('resolved');
+      expect(m._state).to.equal(CachedFuture.Resolved);
     });
 
   });
@@ -189,33 +189,6 @@ describe('CachedFuture', () => {
       const m = Future.of(1).cache();
       const s = 'Future.of(1).cache()';
       expect(m.toString()).to.equal(s);
-    });
-
-  });
-
-  describe('#inspect()', () => {
-
-    it('Visualizes Futures in cold state', () => {
-      const m = Future.of(1).cache();
-      expect(m.inspect()).to.equal('CachedFuture({ <cold> })');
-    });
-
-    it('Visualizes Futures in pending state', () => {
-      const m = Future.after(5, 2).cache();
-      m.run();
-      expect(m.inspect()).to.equal('CachedFuture({ <pending> })');
-    });
-
-    it('Visualizes Futures in pending state', () => {
-      const m = Future(U.noop).cache();
-      m.resolve('hello');
-      expect(m.inspect()).to.equal('CachedFuture({ "hello" })');
-    });
-
-    it('Visualizes Futures in rejected state', () => {
-      const m = Future(U.noop).cache();
-      m.reject('hello');
-      expect(m.inspect()).to.equal('CachedFuture({ <rejected> "hello" })');
     });
 
   });

--- a/test/5.future-map.test.js
+++ b/test/5.future-map.test.js
@@ -78,13 +78,6 @@ describe('FutureMap', () => {
       setTimeout(done, 25);
     });
 
-    it('has custom toString and inspect', () => {
-      const m = Future.of(1).map(x => x);
-      const s = 'Future.of(1).map(x => x)';
-      expect(m.toString()).to.equal(s);
-      expect(m.inspect()).to.equal(s);
-    });
-
   });
 
   describe('#toString()', () => {


### PR DESCRIPTION
After hearing out @safareli's [arguments](https://github.com/fluture-js/concurrify/pull/1#discussion_r98405015) about custom `inspect` for [concurrify](https://github.com/fluture-js/concurrify), I went along and checked if the standard inspect provides useful output, and I would argue that it does:

```js
> Future.after(1, 1).map(x => x + 1).chain(x => Future.of(x)).toString()
'Future.after(1, 1).map(x => x + 1).chain(x => Future.of(x))'

> Future.after(1, 1).map(x => x + 1).chain(x => Future.of(x))
Future {
  _parent: Future { _parent: Future { _time: 1, _value: 1 }, _mapper: [Function] },
  _chainer: [Function] }
```

Reasons for removing custom inspect:

* Default inspect lies within the expectation of a developer
* Default inspect may improve in the future
* `toString` might overflow the stack, potentially giving developers a very bad REPL experience
* Why provide one way to inspect a Future if we can provide two?

---

Should this be considered a breaking change? I would say "no" because `m.inspect` is still `Future ab ~> () -> String` and the string it returns is undocumented and should not be built upon.